### PR TITLE
Don't re-enable org-mode

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -185,7 +185,9 @@ Valid states are 'visible, 'exists and 'none."
       (with-current-buffer org-roam-buffer
         (let ((inhibit-read-only t))
           (erase-buffer)
-          (org-mode)
+          (when (not (eq major-mode 'org-mode))
+            (org-mode))
+
           (make-local-variable 'org-return-follows-link)
           (setq org-return-follows-link t)
           (insert (format "Backlinks for %s:\n\n" file))


### PR DESCRIPTION
If the org-roam buffer is already in org-mode, don't try to re-enable
it (since this essentially turns org-mode hooks into post-command-hooks
and can be computationally expensive).