### PR TITLE
Add polyfill for make-empty-file

### DIFF
--- a/org-roam-polyfill.el
+++ b/org-roam-polyfill.el
@@ -1,0 +1,18 @@
+;; Introduced in Emacs 27.1
+(unless (fboundp 'make-empty-file)
+  (defun make-empty-file (filename &optional parents)
+    "Create an empty file FILENAME.
+Optional arg PARENTS, if non-nil then creates parent dirs as needed.
+
+If called interactively, then PARENTS is non-nil."
+    (interactive
+     (let ((filename (read-file-name "Create empty file: ")))
+       (list filename t)))
+    (when (and (file-exists-p filename) (null parents))
+      (signal 'file-already-exists `("File exists" ,filename)))
+    (let ((paren-dir (file-name-directory filename)))
+      (when (and paren-dir (not (file-exists-p paren-dir)))
+        (make-directory paren-dir parents)))
+    (write-region "" nil filename nil 0)))
+
+(provide'org-roam-polyfill)

--- a/org-roam.el
+++ b/org-roam.el
@@ -5,6 +5,7 @@
 
 ;;; Code:
 (require 'deft)
+(require 'org-roam-polyfill)
 (require 'org-element)
 (require 'async)
 (require 'subr-x)


### PR DESCRIPTION
make-empty-file was only introduced in Emacs 27, which some people are not yet running #17 