### PR TITLE
Add function org-roam-find-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ package manager.
 (use-package org-roam
       :after deft org
       :hook (org-mode . org-roam-mode)
-      :straight (:host "github" :repo "jethrokuan/org-roam")
+      :straight (:host github :repo "jethrokuan/org-roam")
       :bind
-      ("C-c n l" . org-roam)
+      ("C-c n l" . org-roam)      
       ("C-c n t" . org-roam-today)
+      ("C-c n f" . org-roam-find-file)
       ("C-c n i" . org-roam-insert)
       ("C-c n g" . org-roam-show-graph))
 ```

--- a/org-roam.el
+++ b/org-roam.el
@@ -104,7 +104,7 @@ Valid states are 'visible, 'exists and 'none."
     (file-truename org-roam-directory))))
 
 (defun org-roam-insert (id)
-  "Find file `FILE-NAME', insert it as a link with the base file name as the link name."
+  "Find `ID', and insert a relative org link to it at point."
   (interactive (list (completing-read "File: "
                                       (mapcar #'org-roam--get-id
                                               (org-roam--find-all-files)))))
@@ -114,6 +114,16 @@ Valid states are 'visible, 'exists and 'none."
     (insert (format "[[%s][%s]]"
                     (concat "file:" file-path)
                     (concat org-roam-zettel-indicator id)))))
+
+(defun org-roam-find-file (id)
+  "Find and open file with id `ID'."
+  (interactive (list (completing-read "File: "
+                                      (mapcar #'org-roam--get-id
+                                              (org-roam--find-all-files)))))
+  (let ((file-path (org-roam--get-file-path id)))
+    (unless (file-exists-p file-path)
+      (make-empty-file file-path))
+    (find-file file-path)))
 
 (defun org-roam--build-cache-async ()
   "Builds the cache asychronously, saving it into `org-roam-cache'."


### PR DESCRIPTION
org-roam-find-file can be used to quickly navigate to a file in Org-Roam.