### PR TITLE
Add org-roam-tomorrow and org-roam-date

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -228,6 +228,16 @@ If called interactively, then PARENTS is non-nil."
   (interactive)
   (org-roam--new-file-named (format-time-string "%Y-%m-%d" (current-time))))
 
+(defun org-roam-tomorrow ()
+  "Create the file for tomorrow."
+  (interactive)
+  (org-roam--new-file-named (format-time-string "%Y-%m-%d" (time-add 86400 (current-time)))))
+
+(defun org-roam-date ()
+  "Create the file for any date using the calendar."
+  (interactive)
+  (let ((time (org-read-date nil 'to-time nil "Date:  ")))
+    (org-roam--new-file-named (format-time-string "%Y-%m-%d" time))))
 
 ;;; Org-roam buffer updates
 (defun org-global-props (&optional property buffer)


### PR DESCRIPTION
Similar to `org-roam-today`:

- `org-roam-tomorrow`: Add a file for tomorrow
- `org-roam-date`: Add a file for any date (choose via date picker)