### PR TITLE
Add or fix symlink support

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -106,7 +106,7 @@ If called interactively, then PARENTS is non-nil."
               (setq result (append (org-roam--find-files file) result))))
            ((and (file-readable-p file)
                  (string= (file-name-extension file) "org"))
-            (setq result (cons file result)))))
+            (setq result (cons (file-truename file) result)))))
         result)))
 
 (defun org-roam--find-all-files ()


### PR DESCRIPTION
One of the conditions of `org-roam--maybe-update-buffer ` checks the true name of the current buffer. However, When populating `org-roam-files`, the true name is not used. This causes symlinks to not work, at least for me.

This PR adds the true file name to `org-roam-files` instead.