### PR TITLE
Small updates to org-roam buffer

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -4,6 +4,7 @@
 ;;
 
 ;;; Code:
+(require 'dash)
 (require 'org-element)
 (require 'async)
 (require 'subr-x)
@@ -395,11 +396,27 @@ Valid states are 'visible, 'exists and 'none."
     ((get-buffer org-roam-buffer) 'exists)
     (t 'none))))
 
+(defun org-roam--set-width (width)
+  "Set the width of the org-roam buffer to `WIDTH'."
+  (unless (one-window-p)
+    (let ((window-size-fixed)
+          (w (max width window-min-width)))
+      (cond
+       ((> (window-width) w)
+        (shrink-window-horizontally  (- (window-width) w)))
+       ((< (window-width) w)
+        (enlarge-window-horizontally (- w (window-width))))))))
+
 (defun org-roam--setup-buffer ()
   "Setup the `org-roam' buffer at the `org-roam-position'."
-  (display-buffer-in-side-window
-   (get-buffer-create org-roam-buffer)
-   `((side . ,org-roam-position))))
+  (save-excursion
+    (-> (get-buffer-create org-roam-buffer)
+        (display-buffer-in-side-window
+         `((side . ,org-roam-position)))
+        (select-window))
+    (org-roam--set-width
+     (round (* (frame-width)
+               org-roam-buffer-width)))))
 
 (defun org-roam ()
   "Pops up the window `org-roam-buffer' accordingly."

--- a/org-roam.el
+++ b/org-roam.el
@@ -182,11 +182,12 @@ If `ABSOLUTE', return the absolute file-path. Else, return the relative file-pat
                                                                         (string= (file-name-extension path) "org"))
                                                                (goto-char start)
                                                                (let* ((element (org-element-at-point))
-                                                                      (content (buffer-substring
-                                                                                (or (org-element-property :content-begin element)
-                                                                                    (org-element-property :begin element))
-                                                                                (or (org-element-property :content-end element)
-                                                                                    (org-element-property :end element)))))
+                                                                      (content (or (org-element-property :raw-value element)
+                                                                                   (buffer-substring
+                                                                                    (or (org-element-property :content-begin element)
+                                                                                        (org-element-property :begin element))
+                                                                                    (or (org-element-property :content-end element)
+                                                                                        (org-element-property :end element))))))
                                                                  (list :from file
                                                                        :to (file-truename (expand-file-name path org-roam-directory))
                                                                        :content (string-trim content))))))))))
@@ -268,11 +269,12 @@ Before calling this function, `org-roam-cache' should be already populated."
                      (string= (file-name-extension path) "org"))
             (goto-char start)
             (let* ((element (org-element-at-point))
-                   (content (buffer-substring
-                             (or (org-element-property :content-begin element)
-                                 (org-element-property :begin element))
-                             (or (org-element-property :content-end element)
-                                 (org-element-property :end element)))))
+                   (content (or (org-element-property :raw-value element)
+                                (buffer-substring
+                                 (or (org-element-property :content-begin element)
+                                     (org-element-property :begin element))
+                                 (or (org-element-property :content-end element)
+                                     (org-element-property :end element))))))
               (list :from (file-truename (buffer-file-name (current-buffer)))
                     :to (file-truename (expand-file-name path org-roam-directory))
                     :content (string-trim content)))))))))


### PR DESCRIPTION
2 changes:

1. Allows setting of the width of the org-roam buffer (as a percentage of frame-width), with `org-roam-buffer-width`
2. Propertize some the title, and preview contents. Depending on your theme, it might not look as nice. I recommend a theme with a background for `org-block`, or just setting that yourself.