### PR TITLE
Refactoring the cache implementation

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -565,7 +565,7 @@ Valid states are 'visible, 'exists and 'none."
   (unless org-roam-cache-initialized
     (org-roam--build-cache-async))
   (add-hook 'post-command-hook #'org-roam--maybe-update-buffer nil t)
-  (add-hook 'after-save-hook #'org-roam--update-cache))
+  (add-hook 'after-save-hook #'org-roam--update-cache nil t))
 
 (defun org-roam--disable ()
   "Disable org-roam updating for file.


### PR DESCRIPTION
Part of #49 . First order of business was to move the caches into their own variables. This made me discover that the `after-save-hook` was not local, so I fixed that as well.