### PR TITLE
Add documentation for configuration options

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -9,6 +9,19 @@ the flexibility of Emacs, and mould our tools exactly to our liking.
 All of Org-roam's customization options can be viewed via `M-x
 customize-group org-roam`.
 
+## Setting the Org-roam Directory
+
+Perhaps the single most important variable to set is
+`org-roam-directory`. Set `org-roam-directory` to the folder
+containing all your Org files:
+
+```emacs-lisp
+(setq org-roam-directory "/path/to/org/")
+```
+
+Every Org file, at any level of nesting, within `/path/to/org/` is
+considered part of the Org-roam ecosystem.
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -42,6 +42,17 @@ frame width. For example:
 Will result in the Org-roam buffer taking up 40% of the screen width.
 I have found this to be a good number.
 
+## Org-roam Links
+
+By default, links are inserted with the title as the link description.
+This can make them hard to distinguish from external links. If you
+wish, you may choose add special indicators for Org-roam links by
+tweaking `org-roam-link-title-format`, for example:
+
+```emacs-lisp
+(setq org-roam-link-title-format "R:%s")
+```
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,6 +28,9 @@ The Org-roam buffer defaults to popping up from the right. You may
 choose to set it to pop up from the left with `(setq
 org-roam-buffer-position 'left)`.
 
+The Org-roam buffer name can also be renamed: e.g. `(setq
+org-roam-buffer "*my-buffer-name*")`.
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,6 +22,12 @@ containing all your Org files:
 Every Org file, at any level of nesting, within `/path/to/org/` is
 considered part of the Org-roam ecosystem.
 
+## Org-roam Buffer
+
+The Org-roam buffer defaults to popping up from the right. You may
+choose to set it to pop up from the left with `(setq
+org-roam-buffer-position 'left)`.
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and
@@ -61,4 +67,4 @@ commands. The title is specified via the `#+TITLE:` attribute,
 typically near the top of the file. The option
 `org-roam-autopopulate-title` defaults to `t`. When true, the title
 attribute is automatically inserted into the files created via
-org-roam commands. Setting it to `nil` will disable this behaviour.
+Org-roam commands. Setting it to `nil` will disable this behaviour.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -96,3 +96,10 @@ PATH, but if it fails to do so, you may set it manually:
 ```
 (setq org-roam-graphviz-executable "/path/to/dot")
 ```
+
+Org-roam also attempts to use Firefox (located on PATH) to view the
+SVG, you may choose to set it to any compatible program:
+
+```
+(setq org-roam-graph-viewer "/path/to/image-viewer")
+```

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -82,3 +82,17 @@ typically near the top of the file. The option
 `org-roam-autopopulate-title` defaults to `t`. When true, the title
 attribute is automatically inserted into the files created via
 Org-roam commands. Setting it to `nil` will disable this behaviour.
+
+
+## Org-roam Graph Viewer
+
+Org-roam generates an SVG image using
+[Graphviz](https://graphviz.org/). For more information about this
+functionality, see the [Usage](TODO) page.
+
+Org-roam tries its best to locate the Graphviz executable from your
+PATH, but if it fails to do so, you may set it manually:
+
+```
+(setq org-roam-graphviz-executable "/path/to/dot")
+```

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -31,6 +31,17 @@ org-roam-buffer-position 'left)`.
 The Org-roam buffer name can also be renamed: e.g. `(setq
 org-roam-buffer "*my-buffer-name*")`.
 
+The Org-roam buffer width is adjustable via `org-roam-buffer-width`.
+The value of `org-roam-buffer-width` set as a percentage of the total
+frame width. For example:
+
+```emacs-lisp
+(setq org-roam-buffer-width 0.4)
+```
+
+Will result in the Org-roam buffer taking up 40% of the screen width.
+I have found this to be a good number.
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and

--- a/org-roam.el
+++ b/org-roam.el
@@ -19,7 +19,9 @@
   :prefix "org-roam-")
 
 (defcustom org-roam-directory (expand-file-name "~/org-roam/")
-  "Org-roam directory."
+  "Path to Org-roam files.
+
+All Org files, at any level of nesting, is considered part of the Org-roam."
   :type 'directory
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -22,10 +22,10 @@
   "Path to Org-roam files.
 
 All Org files, at any level of nesting, is considered part of the Org-roam."
-  :type 'directory
+  :type 'directoy
   :group 'org-roam)
 
-(defcustom org-roam-position 'right
+(defcustom org-roam-buffer-position 'right
   "Position of `org-roam' buffer.
 
 Valid values are
@@ -555,11 +555,11 @@ Valid states are 'visible, 'exists and 'none."
         (enlarge-window-horizontally (- w (window-width))))))))
 
 (defun org-roam--setup-buffer ()
-  "Setup the `org-roam' buffer at the `org-roam-position'."
+  "Setup the `org-roam' buffer at the `org-roam-buffer-position'."
   (let ((window (get-buffer-window)))
     (-> (get-buffer-create org-roam-buffer)
         (display-buffer-in-side-window
-         `((side . ,org-roam-position)))
+         `((side . ,org-roam-buffer-position)))
         (select-window))
     (org-roam--set-width
      (round (* (frame-width)


### PR DESCRIPTION
Add documentation for all of Org-roam's configuration options (#63 ).

- [x] org-roam-directory
- [x] org-roam-position
- [x] org-roam-file-format
- [x] org-roam-link-title-format
- [x] org-roam-use-timestamp-as-filename
- [x] org-roam-autopopulate-title
- [x] org-roam-buffer
- [x] org-roam-graph-viewer
- [x] org-roam-graphviz-executable