### PR TITLE
fix org-roam--parse-content incorrect :to computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2 (TBD)
+
+### Bugfixes
+* [#86][gh-86] Fix org-roam--parse-content incorrect `:to` computation for nested files
+
 ## 0.1.1 (2020-02-15)
 
 Mostly a documentation/cleanup release.
@@ -31,6 +36,7 @@ Mostly a documentation/cleanup release.
 [gh-75]: https://github.com/jethrokuan/org-roam/pull/75
 [gh-78]: https://github.com/jethrokuan/org-roam/pull/78
 [gh-82]: https://github.com/jethrokuan/org-roam/pull/82
+[gh-86]: https://github.com/jethrokuan/org-roam/pull/86
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -73,11 +73,13 @@
                                (or (org-element-property :content-begin element)
                                    (org-element-property :begin element))
                                (or (org-element-property :content-end element)
-                                   (org-element-property :end element))))))
-            (list :from (or file-path
-                            (file-truename (buffer-file-name (current-buffer))))
-                  :to (file-truename (expand-file-name path org-roam-directory))
-                  :content (string-trim content))))))))
+                                   (org-element-property :end element)))))
+                 (content (string-trim content))
+                 (file-path (or file-path
+                                (file-truename (buffer-file-name (current-buffer))))))
+            (list :from file-path
+                  :to (file-truename (expand-file-name path (file-name-directory file-path)))
+                  :content content)))))))
 
 (cl-defun org-roam--insert-item (item &key forward backward)
   "Insert ITEM into FORWARD and BACKWARD cache.


### PR DESCRIPTION
org-roam--parse-content always computed the to-path relative to the `org-roam-directory`, when it should be relative to the file-path in question. Fixes #81.