### PR TITLE
Look for encrypted org-files (.org.gpg) in files and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.2 (TBD)
 
+### New Features
+* [#87][gh-87] Support encrypted Org files (by [@chip2n](https://github.com/chip2n/))
+
 ### Bugfixes
 * [#86][gh-86] Fix org-roam--parse-content incorrect `:to` computation for nested files
 
@@ -37,6 +40,7 @@ Mostly a documentation/cleanup release.
 [gh-78]: https://github.com/jethrokuan/org-roam/pull/78
 [gh-82]: https://github.com/jethrokuan/org-roam/pull/82
 [gh-86]: https://github.com/jethrokuan/org-roam/pull/86
+[gh-87]: https://github.com/jethrokuan/org-roam/pull/87
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -39,7 +39,7 @@
 (require 'cl-lib)
 
 (defun org-roam--org-file-p (path)
-  "Check if the path is pointing to an org file."
+  "Check if PATH is pointing to an org file."
   (let ((ext (file-name-extension path)))
     (or (string= ext "org")
         (and

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -38,6 +38,14 @@
 (require 'subr-x)
 (require 'cl-lib)
 
+(defun org-roam--org-file-p (path)
+  "Check if the path is pointing to an org file."
+  (let ((ext (file-name-extension path)))
+    (or (string= ext "org")
+        (and
+         (string= ext "gpg")
+         (string= (file-name-extension (file-name-sans-extension path)) "org")))))
+
 (defun org-roam--find-files (dir)
   "Return all `org-roam' files in `DIR'."
   (if (file-exists-p dir)
@@ -53,7 +61,7 @@
             (when (not (string-match dir-ignore-regexp file))
               (setq result (append (org-roam--find-files file) result))))
            ((and (file-readable-p file)
-                 (string= (file-name-extension file) "org"))
+                 (org-roam--org-file-p file))
             (setq result (cons (file-truename file) result)))))
         result)))
 
@@ -65,7 +73,7 @@
             (path (org-element-property :path link))
             (start (org-element-property :begin link)))
         (when (and (string= type "file")
-                   (string= (file-name-extension path) "org"))
+                   (org-roam--org-file-p path))
           (goto-char start)
           (let* ((element (org-element-at-point))
                  (content (or (org-element-property :raw-value element)


### PR DESCRIPTION
Seems to work both for building the initial cache as well as jumping to a note via a back link (password prompt is shown if password not cached).

Fixes #85