### PR TITLE
Add a missed (file-truename org-roam-directory)

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -153,7 +153,7 @@ If called interactively, then PARENTS is non-nil."
   "Return t if file is part of org-roam system, false otherwise."
   (and (buffer-file-name (current-buffer))
        (f-descendant-of-p (file-truename (buffer-file-name (current-buffer)))
-                          org-roam-directory)))
+                          (file-truename org-roam-directory))))
 
 (defun org-roam--get-title-from-cache (file)
   "Return title of `FILE' from the cache."


### PR DESCRIPTION
Fixes org-roam--maybe-enable not working with a symlinked directory. By the way, should all the file-truename calls be optimized somehow?