### PR TITLE
Add support for file encryption by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.1.2 (TBD)
 
 ### New Features
-* [#87][gh-87] Support encrypted Org files (by [@chip2n](https://github.com/chip2n/))
+* [#87][gh-87], [#90][gh-90] Support encrypted Org files (by [@chip2n](https://github.com/chip2n/))
 
 ### Bugfixes
 * [#86][gh-86] Fix org-roam--parse-content incorrect `:to` computation for nested files
@@ -41,6 +41,7 @@ Mostly a documentation/cleanup release.
 [gh-82]: https://github.com/jethrokuan/org-roam/pull/82
 [gh-86]: https://github.com/jethrokuan/org-roam/pull/86
 [gh-87]: https://github.com/jethrokuan/org-roam/pull/87
+[gh-90]: https://github.com/jethrokuan/org-roam/pull/90
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -94,6 +94,15 @@ typically near the top of the file. The option
 attribute is automatically inserted into the files created via
 Org-roam commands. Setting it to `nil` will disable this behaviour.
 
+### Encryption
+
+Encryption (via GPG) can be enabled for all new files by setting
+`org-roam-encrypt-files` to `t`. When enabled, new files are created
+with the .org.gpg extension and decryption are handled automatically
+by EasyPG. Note that this causes Emacs to ask for password when the
+cache is built (if you have an encrypted file in `org-roam-directory`)
+as well as each time a new file is created. It might be a good idea to
+cache the password in order to make this more managable.
 
 ## Org-roam Graph Viewer
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -96,6 +96,11 @@ Valid values are
   :type 'string
   :group 'org-roam)
 
+(defcustom org-roam-encrypt-files nil
+  "Whether to encrypt new files. If true, create files with .org.gpg extension."
+  :type 'boolean
+  :group 'org-roam)
+
 (defcustom org-roam-graph-viewer (executable-find "firefox")
   "Path to executable for viewing SVG."
   :type 'string
@@ -173,7 +178,9 @@ If called interactively, then PARENTS is non-nil."
 If `ABSOLUTE', return the absolute file-path. Else, return the relative file-path."
   (let ((absolute-file-path (file-truename
                              (expand-file-name
-                              (concat id ".org")
+                              (if org-roam-encrypt-files
+                                  (concat id ".org.gpg")
+                                (concat id ".org"))
                               org-roam-directory))))
     (if absolute
         absolute-file-path

--- a/org-roam.el
+++ b/org-roam.el
@@ -172,10 +172,10 @@ If called interactively, then PARENTS is non-nil."
   "Return all org-roam files."
   (org-roam--find-files (file-truename org-roam-directory)))
 
-(defun org-roam--get-file-path (id &optional absolute)
-  "Convert identifier `ID' to file path.
+(defun org-roam--make-new-file-path (id &optional absolute)
+  "Make new file path from identifier `ID'.
 
-If `ABSOLUTE', return the absolute file-path. Else, return the relative file-path."
+If `ABSOLUTE', return an absolute file-path. Else, return a relative file-path."
   (let ((absolute-file-path (file-truename
                              (expand-file-name
                               (if org-roam-encrypt-files
@@ -233,7 +233,7 @@ If not provided, derive the title from the file name."
   "Create a new file named `SLUG'.
 `SLUG' is the short file name, without a path or a file extension."
   (interactive "sNew filename (without extension): ")
-  (let ((file-path (org-roam--get-file-path slug t)))
+  (let ((file-path (org-roam--make-new-file-path slug t)))
     (unless (file-exists-p file-path)
       (org-roam--make-file file-path))
     (find-file file-path)))
@@ -248,7 +248,7 @@ Optionally pass it the title, for a smart file name."
                               (if title
                                   (org-roam--title-to-slug title)
                                 "")))
-           (file-path (org-roam--get-file-path slug t)))
+           (file-path (org-roam--make-new-file-path slug t)))
       (if (file-exists-p file-path)
           (user-error "There's already a file at %s")
         slug))))
@@ -268,7 +268,7 @@ Optionally pass it the title, for a smart file name."
                               (org-roam--find-all-files)))
          (title (completing-read "File: " completions))
          (absolute-file-path (or (cadr (assoc title completions))
-                                 (org-roam--get-file-path (org-roam--get-new-id title) t)))
+                                 (org-roam--make-new-file-path (org-roam--get-new-id title) t)))
          (current-file-path (-> (current-buffer)
                                 (buffer-file-name)
                                 (file-truename)
@@ -289,7 +289,7 @@ Optionally pass it the title, for a smart file name."
                               (org-roam--find-all-files)))
          (title-or-slug (completing-read "File: " completions))
          (absolute-file-path (or (cadr (assoc title-or-slug completions))
-                                 (org-roam--get-file-path
+                                 (org-roam--make-new-file-path
                                   (org-roam--get-new-id title-or-slug) t))))
     (unless (file-exists-p absolute-file-path)
       (org-roam--make-file absolute-file-path title-or-slug))


### PR DESCRIPTION
If org-roam-encrypt-files is t, org-roam creates files with .org.gpg extension instead.

Might be a good idea to rename `org-roam--get-file-path` to `org-roam--make-new-file-path`, since given an existing ID it no longer reliably gets the path for it (could be either encrypted or unencrypted). I think it's only used for creating new files now anyways.

See #85