### PR TITLE
(feature) Add link to backlink line to backlinks buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### New Features
 * [#87][gh-87], [#90][gh-90] Support encrypted Org files
 * [#110][gh-110] Add prefix to `org-roam-insert`, for inserting titles down-cased
+* [#99](https://github.com/jethrokuan/org-roam/pull/99) Add keybinding so that `<return>` or `mouse-1` in the backlinks buffer visits the source file of the backlink at point
 
 ### Bugfixes
 * [#86][gh-86] Fix `org-roam--parse-content` incorrect `:to` computation for nested files
@@ -23,6 +24,7 @@
 ### Contributors
 * [@chip2n](https://github.com/chip2n/)
 * [@l3kn](https://github.com/l3kn/)
+* [@jdormit](https://github.com/jdormit)
 
 ## 0.1.1 (2020-02-15)
 

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -97,13 +97,14 @@ Like file-name-extension, but does not strip version number."
                                 (file-truename (buffer-file-name (current-buffer))))))
             (list :from file-path
                   :to (file-truename (expand-file-name path (file-name-directory file-path)))
-                  :content content)))))))
+                  :content content
+                  :line (line-number-at-pos start t))))))))
 
 (cl-defun org-roam--insert-item (item &key forward backward)
   "Insert ITEM into FORWARD and BACKWARD cache.
 
-ITEM is of the form: (:from from-path :to to-path :content preview-content)."
-  (pcase-let ((`(:from ,p-from :to ,p-to :content ,content) item))
+ITEM is of the form: (:from from-path :to to-path :content preview-content :line line-number)."
+  (pcase-let ((`(:from ,p-from :to ,p-to :content ,content :line ,line) item))
     ;; Build forward-links
     (let ((links (gethash p-from forward)))
       (if links
@@ -116,14 +117,14 @@ ITEM is of the form: (:from from-path :to to-path :content preview-content)."
     (let ((contents-hash (gethash p-to backward)))
       (if contents-hash
           (if-let ((contents-list (gethash p-from contents-hash)))
-              (let ((updated (cons content contents-list)))
+              (let ((updated (cons (cons content line) contents-list)))
                 (puthash p-from updated contents-hash)
                 (puthash p-to contents-hash backward))
             (progn
-              (puthash p-from (list content) contents-hash)
+              (puthash p-from (list (cons content line)) contents-hash)
               (puthash p-to contents-hash backward)))
         (let ((contents-hash (make-hash-table :test #'equal)))
-          (puthash p-from (list content) contents-hash)
+          (puthash p-from (list (cons content line)) contents-hash)
           (puthash p-to contents-hash backward))))))
 
 (defun org-roam--extract-title ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -433,10 +433,13 @@ This is equivalent to removing the node from the graph."
                          (insert (format "** [[file:%s][%s]]\n"
                                          file-from
                                          (org-roam--get-title-or-slug file-from)))
-                         (dolist (content contents)
-                           (insert (concat (propertize (s-trim (s-replace "\n" " " content))
-                                                       'font-lock-face 'org-block)
-                                           "\n\n"))))
+                         (dolist (content-raw contents)
+                           (let ((content (propertize
+					   (s-trim (s-replace "\n" " " (car content-raw)))
+					   'font-lock-face 'org-block))
+				 (line (cdr content-raw)))
+			     (insert (format "%s [[file:%s::%s][(link)]]\n\n"
+					     content file-from line)))))
                        backlinks))
           (insert "\n\n* No backlinks!")))
       (read-only-mode 1)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -407,17 +407,14 @@ This is equivalent to removing the node from the graph."
       (goto-char p)
       (org-show-context))))
 
-(defvar org-roam-backlinks-mode-map (make-sparse-keymap)
-  "Keymap for the org-roam backlinks buffer")
-(define-key org-roam-backlinks-mode-map [mouse-1] 'org-roam-jump-to-backlink)
-(define-key org-roam-backlinks-mode-map (kbd "RET") 'org-roam-jump-to-backlink)
-
-(define-minor-mode org-roam-backlinks-mode
-  "Minor mode for the org-roam backlinks buffer
+(define-derived-mode org-roam-backlinks-mode org-mode "Backlinks"
+  "Major mode for the org-roam backlinks buffer
 
 Bindings:
-\\{org-roam-backlinks-mode-map}"
-  :keymap org-roam-backlinks-mode-map)
+\\{org-roam-backlinks-mode-map}")
+
+(define-key org-roam-backlinks-mode-map [mouse-1] 'org-roam-jump-to-backlink)
+(define-key org-roam-backlinks-mode-map (kbd "RET") 'org-roam-jump-to-backlink)
 
 ;;; Org-roam buffer updates
 
@@ -441,8 +438,8 @@ Bindings:
        (cons '(file . org-roam--find-file) org-link-frame-setup))
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (when (not (eq major-mode 'org-mode))
-          (org-mode))
+        (when (not (eq major-mode 'org-roam-backlinks-mode))
+          (org-roam-backlinks-mode))
         (make-local-variable 'org-return-follows-link)
         (setq org-return-follows-link t)
         (insert
@@ -466,7 +463,6 @@ Bindings:
                              (insert (format "%s \n\n" content)))))
                        backlinks))
           (insert "\n\n* No backlinks!")))
-      (org-roam-backlinks-mode)
       (read-only-mode 1)))
   (setq org-roam-current-file file-path))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -413,7 +413,10 @@ This is equivalent to removing the node from the graph."
 (define-key org-roam-backlinks-mode-map (kbd "RET") 'org-roam-jump-to-backlink)
 
 (define-minor-mode org-roam-backlinks-mode
-  "Minor mode for the org-roam backlinks buffer"
+  "Minor mode for the org-roam backlinks buffer
+
+Bindings:
+\\{org-roam-backlinks-mode-map}"
   :keymap org-roam-backlinks-mode-map)
 
 ;;; Org-roam buffer updates

--- a/org-roam.el
+++ b/org-roam.el
@@ -397,6 +397,25 @@ This is equivalent to removing the node from the graph."
   (let ((time (org-read-date nil 'to-time nil "Date:  ")))
     (org-roam--new-file-named (format-time-string "%Y-%m-%d" time))))
 
+(defun org-roam-jump-to-backlink ()
+  "Jumps to original file and location of the backlink content snippet at point"
+  (interactive)
+  (let ((file-from (get-text-property (point) 'file-from))
+        (p (get-text-property (point) 'file-from-point)))
+    (when (and file-from p)
+      (find-file file-from)
+      (goto-char p)
+      (org-show-context))))
+
+(defvar org-roam-backlinks-mode-map (make-sparse-keymap)
+  "Keymap for the org-roam backlinks buffer")
+(define-key org-roam-backlinks-mode-map [mouse-1] 'org-roam-jump-to-backlink)
+(define-key org-roam-backlinks-mode-map (kbd "RET") 'org-roam-jump-to-backlink)
+
+(define-minor-mode org-roam-backlinks-mode
+  "Minor mode for the org-roam backlinks buffer"
+  :keymap org-roam-backlinks-mode-map)
+
 ;;; Org-roam buffer updates
 
 (defun org-roam--find-file (file)
@@ -433,15 +452,18 @@ This is equivalent to removing the node from the graph."
                          (insert (format "** [[file:%s][%s]]\n"
                                          file-from
                                          (org-roam--get-title-or-slug file-from)))
-                         (dolist (content-raw contents)
+                         (dolist (properties contents)
                            (let ((content (propertize
-					   (s-trim (s-replace "\n" " " (car content-raw)))
-					   'font-lock-face 'org-block))
-				 (line (cdr content-raw)))
-			     (insert (format "%s [[file:%s::%s][(link)]]\n\n"
-					     content file-from line)))))
+                                           (s-trim (s-replace "\n" " "
+                                                              (plist-get properties :content)))
+                                           'font-lock-face 'org-block
+                                           'help-echo "mouse-1: visit backlinked note"
+                                           'file-from file-from
+                                           'file-from-point (plist-get properties :point))))
+                             (insert (format "%s \n\n" content)))))
                        backlinks))
           (insert "\n\n* No backlinks!")))
+      (org-roam-backlinks-mode)
       (read-only-mode 1)))
   (setq org-roam-current-file file-path))
 


### PR DESCRIPTION
This adds a link that goes directly to the line containing the backlink for each entry in the backlinks buffer. It does this by changing the the data structure in the backlinks cache that stores content from being a list of content strings to a list of cons pairs, where the `car` of the pair is the content string and the `cdr` of the pair is the line number where the content was found. This structure allows the backlinks buffer to link directly to the content lines in the linking file rather than just linking to the file as a whole.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/6351890/74622745-fb423180-510f-11ea-8d11-b99f06ebbeaa.png">