### PR TITLE
(breaking): change org-roam-file-format to a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 * [#87][gh-87], [#90][gh-90] Support encrypted Org files (by [@chip2n](https://github.com/chip2n/))
 
 ### Bugfixes
-* [#86][gh-86] Fix org-roam--parse-content incorrect `:to` computation for nested files
+* [#86][gh-86] Fix `org-roam--parse-content` incorrect `:to` computation for nested files
+
+### Breaking Changes
+* [#103][gh-103] Change `org-roam-file-format` to a function: `org-roam-file-name-function` to allow more flexible file name customizaton. Also changes `org-roam-use-timestamp-as-filename` to `org-roam-filename-noconfirm` to better describe what it does.
 
 ## 0.1.1 (2020-02-15)
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -66,24 +66,20 @@ Org files in all of its main commands (`org-roam-insert`,
 `org-roam-find-file`). Hence, having any unique file name is a decent
 option, and the default workflow uses the timestamp as the filename.
 
-The format of the filename is specified by the string
-`org-roam-file-format`, which defaults to `"%Y%m%d%H%M%S"`. To see
-valid specifications, see the help (`C-h f`) for `format-time-string`.
+The format of the filename is controlled by the function
+`org-roam-file-name-function`, which defaults to a format like
+`YYYYMMDDHHMMSS_title_here.org`. You may choose to define your own
+function to change this.
 
-There are several reasons for keeping filenames meaningful. For
-example, one may wish to publish the Org files, and some publishing
-methods such as Org-publish use the file names as slugs for the URLs.
-
-If you wish to maintain manual control of filenames, set
-`org-roam-use-timestamp-as-filename` to `nil`:
+If you wish to be prompted to change the file name on creation, set
+`org-roam-filename-noconfirm` to `nil`:
 
 ```emacs-lisp
-(setq org-roam-use-timestamp-as-filename nil)
+(setq org-roam-filename-noconfirm nil)
 ```
 
-When this setting is turned off, the user is instead manually prompted
-for a filename. It is then the user's responsibility to ensure that
-the file names are unique.
+It is then the user's responsibility to ensure that the file names are
+unique.
 
 ### Autopopulating Titles
 


### PR DESCRIPTION
The new function is controlled by variable `org-roam-file-name-function`.

This allows for more flexible naming of files. Now filename defaults
to yyyymmddhhmmss_title_here.org. Also, remove
`org-use-timestamp-as-filename`, and change it to
`org-roam-filename-noconfirm` to better describe what it is doing.