### PR TITLE
(tests): add tests for org-roam-insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.sandbox/
+**/*.elc

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-let
-  pkgs = import <nixpkgs> {};
-in
-pkgs.mkShell {
-  name = "docs";
-  buildInput = with pkgs; [
-    mkdocs
-  ];
-}


### PR DESCRIPTION
Testing the basic combinations for `org-roam-insert`.