### PR TITLE
WIP: Add org_roam_file link type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Mostly a documentation/cleanup release.
 [gh-98]: https://github.com/jethrokuan/org-roam/pull/98
 [gh-103]: https://github.com/jethrokuan/org-roam/pull/103
 [gh-105]: https://github.com/jethrokuan/org-roam/pull/105
+[gh-108]: https://github.com/jethrokuan/org-roam/pull/108
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.2 (TBD)
 
+### Changes
+
+* [#108][gh-108] Locally overwrite the link following behaviour in the org-roam-buffer to open files in the same window `org-roam` was called from
+
 ### Breaking Changes
 * [#103][gh-103] Change `org-roam-file-format` to a function: `org-roam-file-name-function` to allow more flexible file name customizaton. Also changes `org-roam-use-timestamp-as-filename` to `org-roam-filename-noconfirm` to better describe what it does.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -397,19 +397,22 @@ This is equivalent to removing the node from the graph."
 
 (defun org-roam--find-file (file)
   "Open FILE in the window `org-roam' was called from."
-  (if org-roam-last-window
+  (if (and org-roam-last-window (window-valid-p org-roam-last-window))
       (progn (with-selected-window org-roam-last-window
                (find-file file))
              (select-window org-roam-last-window))
     (find-file file)))
-
-(org-link-set-parameters "org_roam_file" :follow #'org-roam--find-file)
 
 (defun org-roam-update (file-path)
   "Show the backlinks for given org file for file at `FILE-PATH'."
   (org-roam--ensure-cache-built)
   (let ((buffer-title (org-roam--get-title-or-slug file-path)))
     (with-current-buffer org-roam-buffer
+      ;; Locally overwrite the file opening function to re-use the
+      ;; last window org-roam was called from
+      (setq-local
+       org-link-frame-setup
+       (cons '(file . org-roam--find-file) org-link-frame-setup))
       (let ((inhibit-read-only t))
         (erase-buffer)
         (when (not (eq major-mode 'org-mode))
@@ -423,7 +426,7 @@ This is equivalent to removing the node from the graph."
               (insert (format "\n\n* %d Backlinks\n"
                               (hash-table-count backlinks)))
               (maphash (lambda (file-from contents)
-                         (insert (format "** [[org_roam_file:%s][%s]]\n"
+                         (insert (format "** [[file:%s][%s]]\n"
                                          file-from
                                          (org-roam--get-title-or-slug file-from)))
                          (dolist (content contents)


### PR DESCRIPTION
Add a custom org-mode link type that reuses the last window `org-roam` was called from to open files,
for use in the org-roam buffer.

Closes issue #30

@jethrokuan Should this go under "New Features" or "Internal" in the changelog?