### PR TITLE
Add autoload to org-roam-mode

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -543,6 +543,7 @@ This needs to be quick/infrequent, because this is run at
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))
 
+;;;###autoload
 (define-minor-mode org-roam-mode
   "Global minor mode to automatically update the org-roam buffer."
   :require 'org-roam


### PR DESCRIPTION
I am super excited to start using this package. It looks really well done. 

With this change it is no longer required to load org-roam before use. You can just add the `org-roam-mode` to `org-mode-hook` and it will load the package when needed.

