### PR TITLE
Increase performance of post-command-hook

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -536,8 +536,9 @@ Valid states are 'visible, 'exists and 'none."
 This needs to be quick/infrequent, because this is run at
 `post-command-hook'."
   (let ((buffer (window-buffer)))
-    (when (or redisplay
-              (not (eq org-roam--current-buffer buffer)))
+    (when (and (or redisplay
+                   (not (eq org-roam--current-buffer buffer)))
+               (eq 'visible (org-roam--current-visibility)))
       (setq org-roam--current-buffer buffer)
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -149,7 +149,7 @@ If called interactively, then PARENTS is non-nil."
 (defvar org-roam-titles-cache (make-hash-table :test #'equal)
   "Cache containing titles for org-roam files.")
 
-(defvar org-roam-current-file nil
+(defvar org-roam--current-buffer nil
   "Currently displayed file in `org-roam' buffer.")
 
 (defvar org-roam-last-window nil
@@ -463,8 +463,7 @@ Bindings:
                              (insert (format "%s \n\n" content)))))
                        backlinks))
           (insert "\n\n* No backlinks!")))
-      (read-only-mode 1)))
-  (setq org-roam-current-file file-path))
+      (read-only-mode 1))))
 
 ;;; Show/hide the org-roam buffer
 (define-inline org-roam--current-visibility ()
@@ -529,21 +528,19 @@ Valid states are 'visible, 'exists and 'none."
   "Disable org-roam updating for file.
 
 1. Remove hooks for updating the cache, and the org-roam buffer."
-  (remove-hook 'post-command-hook #'org-roam--maybe-update-buffer)
-  (remove-hook 'after-save-hook #'org-roam--update-cache))
+  (remove-hook 'post-command-hook #'org-roam--maybe-update-buffer t)
+  (remove-hook 'after-save-hook #'org-roam--update-cache t))
 
 (cl-defun org-roam--maybe-update-buffer (&key redisplay)
   "Update `org-roam-buffer' with the necessary information.
 This needs to be quick/infrequent, because this is run at
 `post-command-hook'."
-  (with-current-buffer (window-buffer)
-    (when (and (get-buffer org-roam-buffer)
-               (buffer-file-name (current-buffer))
-               (file-exists-p (file-truename (buffer-file-name (current-buffer))))
-               (or redisplay
-                   (not (string= org-roam-current-file
-                                 (file-truename (buffer-file-name (current-buffer)))))))
-      (org-roam-update (file-truename (buffer-file-name (window-buffer)))))))
+  (let ((buffer (window-buffer)))
+    (when (or redisplay
+              (not (eq org-roam--current-buffer buffer)))
+      (setq org-roam--current-buffer buffer)
+      (org-roam-update (expand-file-name
+                        (buffer-local-value 'buffer-file-truename buffer))))))
 
 (define-minor-mode org-roam-mode
   "Global minor mode to automatically update the org-roam buffer."


### PR DESCRIPTION
`file-truename` can be an expensive function on a slow filesystem like NFS. I removed a lot of the unneeded code and refactored to improve performance. In my testing it took the execution time from `13ms` per call to `2µs`; over a 1000x speedup. This is important since `post-command-hook` is called with every character you type.

This change is a little more involved, so let me know what you think.

On a separate note, Another thing I noticed is that you code has a lot of `(buffer-file-name (current-buffer)` and `(file-truename (buffer-file-name (current-buffer)))`. Both of these values are cached in buffer local variables with `buffer-file-name` and `(expand-file-name buffer-file-truename)` respectively. It might be worth it it use the cached variables instead of calling the functions.