### PR TITLE
allow customization of graphviz node appearance

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -116,6 +116,16 @@ If nil, always ask for filename."
   :type 'string
   :group 'org-roam)
 
+(defcustom org-roam-graph-max-title-length 100
+  "Maximum length of titles in graphviz graph nodes"
+  :type 'number
+  :group 'org-roam)
+
+(defcustom org-roam-graph-node-shape "elipse"
+  "Maximum length of titles in graphviz graph nodes"
+  :type 'string
+  :group 'org-roam)
+
 ;;; Polyfills
 ;; These are for functions I use that are only available in newer Emacs
 
@@ -556,21 +566,33 @@ This needs to be quick/infrequent, because this is run at
   "Build graphviz graph output."
   (org-roam--ensure-cache-built)
   (with-temp-buffer
-    (insert "digraph {\n")
-    (dolist (file (org-roam--find-all-files))
-      (insert
-       (format "  \"%s\" [URL=\"roam://%s\"];\n"
-               (org-roam--get-title-or-slug file)
-               file)))
-    (maphash
-     (lambda (from-link to-links)
-       (dolist (to-link to-links)
-         (insert (format "  \"%s\" -> \"%s\";\n"
-                         (org-roam--get-title-or-slug from-link)
-                         (org-roam--get-title-or-slug to-link)))))
-     org-roam-forward-links-cache)
-    (insert "}")
-    (buffer-string)))
+	(insert "digraph {\n")
+	(dolist (file (org-roam--find-all-files))
+	  (insert
+	   (let ((title (org-roam--get-title-or-slug file)))
+		 (let ((shortened-title (if (> (length title) org-roam-graph-max-title-length)
+									(concat (substring
+											 title
+											 0
+											 (min (length title) org-roam-graph-max-title-length))
+											"...")
+								  title)))
+		   (format "  \"%s\" [label=\"%s\", shape=%s, URL=\"roam://%s\", tooltip=\"%s\"];\n"
+				   title
+				   shortened-title
+				   org-roam-graph-node-shape
+				   file
+				   title
+				   )))))
+	  (maphash
+	   (lambda (from-link to-links)
+		 (dolist (to-link to-links)
+		   (insert (format "  \"%s\" -> \"%s\";\n"
+						   (org-roam--get-title-or-slug from-link)
+						   (org-roam--get-title-or-slug to-link)))))
+	   org-roam-forward-links-cache)
+	  (insert "}")
+	  (buffer-string)))
 
 (defun org-roam-show-graph ()
   "Generate the org-roam graph in SVG format, and display it using `org-roam-graph-viewer'."

--- a/org-roam.el
+++ b/org-roam.el
@@ -543,6 +543,7 @@ This needs to be quick/infrequent, because this is run at
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))
 
+;;;###autoload
 (define-minor-mode org-roam-mode
   "Global minor mode to automatically update the org-roam buffer."
   :require 'org-roam

--- a/org-roam.el
+++ b/org-roam.el
@@ -568,15 +568,9 @@ This needs to be quick/infrequent, because this is run at
   (with-temp-buffer
 	(insert "digraph {\n")
 	(dolist (file (org-roam--find-all-files))
-	  (insert
-	   (let ((title (org-roam--get-title-or-slug file)))
-		 (let ((shortened-title (if (> (length title) org-roam-graph-max-title-length)
-									(concat (substring
-											 title
-											 0
-											 (min (length title) org-roam-graph-max-title-length))
-											"...")
-								  title)))
+	  (let ((title (org-roam--get-title-or-slug file)))
+		(let ((shortened-title (s-truncate org-roam-graph-max-title-length title)))
+		  (insert
 		   (format "  \"%s\" [label=\"%s\", shape=%s, URL=\"roam://%s\", tooltip=\"%s\"];\n"
 				   title
 				   shortened-title

--- a/org-roam.el
+++ b/org-roam.el
@@ -121,7 +121,7 @@ If nil, always ask for filename."
   :type 'number
   :group 'org-roam)
 
-(defcustom org-roam-graph-node-shape "elipse"
+(defcustom org-roam-graph-node-shape "ellipse"
   "Maximum length of titles in graphviz graph nodes"
   :type 'string
   :group 'org-roam)


### PR DESCRIPTION
This pull request allows the customization of the appearance of exported graphviz nodes.

Two new customizable variables were introduced:
- `org-roam-graph-max-title-length` (default value: `100`)
- `org-roam-graph-node-shape` (default value: `ellipse`)

If the title length is longer than `org-roam-graph-max-title-length`, the title is shortened and `...` is concatenated to the end of the title.

`org-roam-graph-node-shape` is simply a string that is passed to the shape option of the node definition.