### PR TITLE
Handle nil file names

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -166,8 +166,9 @@ If called interactively, then PARENTS is non-nil."
   "Return t if FILE is part of org-roam system, defaulting to the name of the current buffer. Else, return nil."
   (let ((path (or file
                   (buffer-file-name (current-buffer)))))
-    (f-descendant-of-p (file-truename path)
-                       (file-truename org-roam-directory))))
+    (and path
+         (f-descendant-of-p (file-truename path)
+                            (file-truename org-roam-directory)))))
 
 (defun org-roam--get-title-from-cache (file)
   "Return title of `FILE' from the cache."


### PR DESCRIPTION
###### Motivation for this change
I ran into trouble evaluating source blocks in an org document having nothing to do with org-roam. This function was encountering an error whenever I evaluated the source block due to `nil` being passed to `file-truename`. We can detect that, and avoid the trouble.
