### PR TITLE
inject "load-path" variables before building cache asychronously

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -323,6 +323,7 @@ If PREFIX, downcase the title before insertion."
   (interactive)
   (async-start
    `(lambda ()
+      ,(async-inject-variables "load-path")
       (setq load-path ',load-path)
       (package-initialize)
       (require 'org-roam-utils)


### PR DESCRIPTION
###### Motivation for this change
The error I faced is reported in [here](https://github.com/jethrokuan/org-roam/issues/131)
you need to inject load-path otherwise it does not find `org-roam-utils`