### PR TITLE
(feature): add a variable `org-roam-new-file-directory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#103][gh-103] Change `org-roam-file-format` to a function: `org-roam-file-name-function` to allow more flexible file name customizaton. Also changes `org-roam-use-timestamp-as-filename` to `org-roam-filename-noconfirm` to better describe what it does.
 
 ### New Features
+* [#141][gh-141] add variable `org-roam-new-file-directory` for new Org-roam files
 * [#138][gh-138] add `org-roam-switch-to-buffer`
 * [#124][gh-124] Maintain cache consistency on file rename
 * [#87][gh-87], [#90][gh-90] Support encrypted Org files
@@ -75,9 +76,11 @@ Mostly a documentation/cleanup release.
 [gh-108]: https://github.com/jethrokuan/org-roam/pull/108
 [gh-110]: https://github.com/jethrokuan/org-roam/pull/110
 [gh-122]: https://github.com/jethrokuan/org-roam/pull/122
+[gh-124]: https://github.com/jethrokuan/org-roam/pull/124
 [gh-128]: https://github.com/jethrokuan/org-roam/pull/128
 [gh-136]: https://github.com/jethrokuan/org-roam/pull/136
 [gh-138]: https://github.com/jethrokuan/org-roam/pull/138
+[gh-141]: https://github.com/jethrokuan/org-roam/pull/141
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -58,6 +58,13 @@ All Org files, at any level of nesting, is considered part of the Org-roam."
   :type 'directory
   :group 'org-roam)
 
+(defcustom org-roam-new-file-directory nil
+  "Path to where new Org-roam files are created.
+
+If nil, default to the org-roam-directory (preferred)."
+  :type 'directory
+  :group 'org-roam)
+
 (defcustom org-roam-buffer-position 'right
   "Position of `org-roam' buffer.
 
@@ -191,7 +198,8 @@ If `ABSOLUTE', return an absolute file-path. Else, return a relative file-path."
                               (if org-roam-encrypt-files
                                   (concat id ".org.gpg")
                                 (concat id ".org"))
-                              org-roam-directory))))
+                              (or org-roam-new-file-directory
+                                  org-roam-directory)))))
     (if absolute
         absolute-file-path
       (file-relative-name absolute-file-path
@@ -242,9 +250,9 @@ If not provided, derive the title from the file name."
   "Create an org-roam file at FILE-PATH, optionally setting the TITLE attribute."
   (if (file-exists-p file-path)
       (error (format "Aborting, file already exists at %s" file-path))
+    (make-empty-file file-path t)
     (if org-roam-autopopulate-title
-        (org-roam--populate-title file-path title)
-      (make-empty-file file-path))
+        (org-roam--populate-title file-path title))
     (save-excursion
       (with-current-buffer (find-file-noselect file-path)
         (org-roam--update-cache)))))


### PR DESCRIPTION
Adds a new variable `org-roam-new-file-directory` for new Org-roam files.

###### Motivation for this change
#140 