### PR TITLE
Add advice to delete-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### New Features
 * [#141][gh-141] add variable `org-roam-new-file-directory` for new Org-roam files
 * [#138][gh-138] add `org-roam-switch-to-buffer`
-* [#124][gh-124] Maintain cache consistency on file rename
+* [#124][gh-124], [#141][gh-141] Maintain cache consistency on file rename and delete
 * [#87][gh-87], [#90][gh-90] Support encrypted Org files
 * [#110][gh-110] Add prefix to `org-roam-insert`, for inserting titles down-cased
 * [#99][gh-99] Add keybinding so that `<return>` or `mouse-1` in the backlinks buffer visits the source file of the backlink at point
@@ -81,6 +81,7 @@ Mostly a documentation/cleanup release.
 [gh-136]: https://github.com/jethrokuan/org-roam/pull/136
 [gh-138]: https://github.com/jethrokuan/org-roam/pull/138
 [gh-141]: https://github.com/jethrokuan/org-roam/pull/141
+[gh-142]: https://github.com/jethrokuan/org-roam/pull/142
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -664,6 +664,7 @@ This needs to be quick/infrequent, because this is run at
         (org-roam--update-cache)))))
 
 (advice-add 'rename-file :after 'org-roam--rename-file-links)
+(advice-add 'delete-file :before 'org-roam--clear-file-from-cache)
 
 (provide 'org-roam)
 

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -211,3 +211,19 @@
               (expect (with-temp-buffer
                         (insert-file-contents (abs-path "f3.org"))
                         (buffer-string)) :to-match (regexp-quote "[[file:meaningful-title.org][meaningful-title]]"))))
+
+(describe "delete file updates cache"
+          (before-each
+           (org-roam--test-init)
+           (org-roam--clear-cache)
+           (org-roam--test-build-cache))
+          (it "delete f1"
+              (delete-file (abs-path "f1.org"))
+              (expect (->> org-roam-forward-links-cache
+                           (gethash (abs-path "f1.org"))) :to-be nil)
+              (expect (->> org-roam-backward-links-cache
+                           (gethash (abs-path "nested/f1.org"))
+                           (gethash (abs-path "f1.org"))) :to-be nil)
+              (expect (->> org-roam-backward-links-cache
+                           (gethash (abs-path "nested/f1.org"))
+                           (gethash (abs-path "nested/f2.org"))) :not :to-be nil)))


### PR DESCRIPTION
Maintains cache-consistency on file-deletes. Caveat: doesn't check if other files link to this file before deleting.

###### Motivation for this change
https://github.com/jethrokuan/org-roam/issues/119