### PR TITLE
(feature): global org-roam-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#108][gh-108] Locally overwrite the link following behaviour in the org-roam-buffer to open files in the same window `org-roam` was called from
 
 ### Breaking Changes
+* [#143][gh-143] `org-roam-mode` is now a global mode. The installation instructions have changed accordingly.
 * [#103][gh-103] Change `org-roam-file-format` to a function: `org-roam-file-name-function` to allow more flexible file name customizaton. Also changes `org-roam-use-timestamp-as-filename` to `org-roam-filename-noconfirm` to better describe what it does.
 
 ### New Features
@@ -82,6 +83,7 @@ Mostly a documentation/cleanup release.
 [gh-138]: https://github.com/jethrokuan/org-roam/pull/138
 [gh-141]: https://github.com/jethrokuan/org-roam/pull/141
 [gh-142]: https://github.com/jethrokuan/org-roam/pull/142
+[gh-142]: https://github.com/jethrokuan/org-roam/pull/143
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/README.md
+++ b/README.md
@@ -43,19 +43,16 @@ The recommended method is using use-package and straight, or a similar package m
 (use-package org-roam
       :after org
       :hook 
-      ((org-mode . org-roam-mode)
-       (after-init . org-roam--build-cache-async) ;; optional!
-       )
+      (after-init . org-roam-mode)
       :straight (:host github :repo "jethrokuan/org-roam" :branch "develop")
       :custom
       (org-roam-directory "/path/to/org-files/")
-      :bind
-      ("C-c n l" . org-roam)
-      ("C-c n t" . org-roam-today)
-      ("C-c n f" . org-roam-find-file)
-      ("C-c n b" . org-roam-switch-to-buffer)
-      ("C-c n i" . org-roam-insert)
-      ("C-c n g" . org-roam-show-graph))
+      :bind (:map org-roam-mode-map
+              (("C-c n l" . org-roam)
+               ("C-c n f" . org-roam-find-file)
+               ("C-c n g" . org-roam-show-graph))
+              :map org-mode-map
+              (("C-c n i" . org-roam-insert))))
 ```
 
 For more detailed installation instructions (including instructions for

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -7,19 +7,16 @@ The recommended method is using [use-package][use-package] and
 (use-package org-roam
       :after org
       :hook 
-      ((org-mode . org-roam-mode)
-       (after-init . org-roam--build-cache-async) ;; optional!
-       )
+      (after-init . org-roam-mode)
       :straight (:host github :repo "jethrokuan/org-roam" :branch "develop")
       :custom
       (org-roam-directory "/path/to/org-files/")
-      :bind
-      ("C-c n l" . org-roam)
-      ("C-c n t" . org-roam-today)
-      ("C-c n f" . org-roam-find-file)
-      ("C-c n b" . org-roam-switch-to-buffer)
-      ("C-c n i" . org-roam-insert)
-      ("C-c n g" . org-roam-show-graph))
+      :bind (:map org-roam-mode-map
+              (("C-c n l" . org-roam)
+               ("C-c n f" . org-roam-find-file)
+               ("C-c n g" . org-roam-show-graph))
+              :map org-mode-map
+              (("C-c n i" . org-roam-insert))))
 ```
 
 If not using package.el, you can also clone it into your Emacs
@@ -34,18 +31,16 @@ git clone https://github.com/jethrokuan/org-roam/ ~/.emacs.d/elisp/org-roam
       :after org
       :load-path "elisp/"
       :hook 
-      ((org-mode . org-roam-mode)
-       (after-init . org-roam--build-cache-async) ;; optional!
-       )
+      (after-init . org-roam-mode)
+      :straight (:host github :repo "jethrokuan/org-roam" :branch "develop")
       :custom
       (org-roam-directory "/path/to/org-files/")
-      :bind
-      ("C-c n l" . org-roam)
-      ("C-c n t" . org-roam-today)
-      ("C-c n f" . org-roam-find-file)
-      ("C-c n b" . org-roam-switch-to-buffer)
-      ("C-c n i" . org-roam-insert)
-      ("C-c n g" . org-roam-show-graph))
+      :bind (:map org-roam-mode-map
+              (("C-c n l" . org-roam)
+               ("C-c n f" . org-roam-find-file)
+               ("C-c n g" . org-roam-show-graph))
+              :map org-mode-map
+              (("C-c n i" . org-roam-insert))))
 ```
 
 Or without use-package:
@@ -73,9 +68,7 @@ If you are using Spacemacs, you can easily install org-roam by creating a simple
     (use-package org-roam
         :after org
         :hook
-        ((org-mode . org-roam-mode)
-         (after-init . org-roam--build-cache-async) ;; optional!
-         )
+        (after-init . org-roam-mode)
         :custom
         (org-roam-directory "/path/to/org-files/")
         :init
@@ -91,9 +84,10 @@ If you are using Spacemacs, you can easily install org-roam by creating a simple
           (spacemacs/set-leader-keys-for-major-mode 'org-mode
             "rl" 'org-roam
             "rt" 'org-roam-today
+            "rb" 'org-roam-switch-to-buffer
             "rf" 'org-roam-find-file
             "ri" 'org-roam-insert
-            "rg" 'org-roam-show-graph)
-          )))
+            "rg" 'org-roam-show-graph))))
 ```
+
 Next, append `org-roam` to the `dotspacemacs-configuration-layers` list in your `.spacemacs` configuration file. Reload (`SPC f e R`) or restart Emacs to load `org-roam`. It's functions are available under the prefix `SPC a r` and `, r` when visiting an org-mode buffer. 

--- a/org-roam.el
+++ b/org-roam.el
@@ -625,7 +625,7 @@ If ARG is `toggle', toggle `org-roam-mode'. Otherwise, behave as if called inter
     (unless org-roam-cache-initialized
       (org-roam--build-cache-async))
     (add-hook 'find-file-hook #'org-roam--find-file-hook-function)
-    (advice-add 'rename-file :after #'org-roam--rename-file-links)
+    (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice))
    (t
     (remove-hook 'find-file-hook #'org-roam--find-file-hook-function)

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -46,7 +46,8 @@
   (let ((original-dir org-roam--tests-directory)
         (new-dir (expand-file-name (make-temp-name "org-roam") temporary-file-directory)))
     (copy-directory original-dir new-dir)
-    (setq org-roam-directory new-dir)))
+    (setq org-roam-directory new-dir))
+  (org-roam-mode +1))
 
 (defun org-roam--test-build-cache ()
   "Builds the caches synchronously."


### PR DESCRIPTION
Makes org-roam-mode a global minor mode. This mode adds an advice to `find-file-function`, which decides whether to turn on the local post-command-hook and after-save-hook.

It also advices delete-file and rename-file to ensure cache consistency.
  
###### Motivation for this change
Ensures that Org-roam can be cleanly turned on and off. 

Also, fixes a bug introduced with the advice for #142 . 