### PR TITLE
Fallback to Emacs SVG viewer functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#103][gh-103] Change `org-roam-file-format` to a function: `org-roam-file-name-function` to allow more flexible file name customizaton. Also changes `org-roam-use-timestamp-as-filename` to `org-roam-filename-noconfirm` to better describe what it does.
 
 ### New Features
+* [#145][gh-145] `org-roam-show-graph`: Fallback to Emacs SVG viewer
 * [#141][gh-141] add variable `org-roam-new-file-directory` for new Org-roam files
 * [#138][gh-138] add `org-roam-switch-to-buffer`
 * [#124][gh-124], [#141][gh-141] Maintain cache consistency on file rename and delete

--- a/org-roam.el
+++ b/org-roam.el
@@ -551,7 +551,9 @@ Bindings:
     (with-temp-file temp-dot
       (insert graph))
     (call-process org-roam-graphviz-executable nil 0 nil temp-dot "-Tsvg" "-o" temp-graph)
-    (call-process org-roam-graph-viewer nil 0 nil temp-graph)))
+    (if (and org-roam-graph-viewer (executable-find org-roam-graph-viewer))
+	(call-process org-roam-graph-viewer nil 0 nil temp-graph)
+      (view-file temp-graph))))
 
 ;;; Org-roam minor mode
 (cl-defun org-roam--maybe-update-buffer (&key redisplay)


### PR DESCRIPTION
If your Emacs build has SVG support (most likely), you can view SVGs without using an external program.