### PR TITLE
Insert with region keep text

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -303,14 +303,15 @@ If PREFIX, downcase the title before insertion."
   (let* ((region (and (region-active-p)
                       ;; following may lose active region, so save it
                       (cons (region-beginning) (region-end))))
+         (region-text (when region
+                        (buffer-substring-no-properties
+                         (car region) (cdr region))))
          (completions (mapcar (lambda (file)
                                 (list (org-roam--get-title-or-slug file)
                                       file))
                               (org-roam--find-all-files)))
-         (title (completing-read "File: " completions nil nil
-                                 (when region
-                                   (buffer-substring-no-properties
-                                    (car region) (cdr region)))))
+         (title (completing-read "File: " completions nil nil region-text))
+         (region-or-title (or region-text title))
          (absolute-file-path (or (cadr (assoc title completions))
                                  (org-roam--make-new-file-path (org-roam--get-new-id title) t)))
          (current-file-path (-> (or (buffer-base-buffer)
@@ -327,8 +328,8 @@ If PREFIX, downcase the title before insertion."
                     (concat "file:" (file-relative-name absolute-file-path
                                                         current-file-path))
                     (format org-roam-link-title-format (if prefix
-                                                           (downcase title)
-                                                         title))))))
+                                                           (downcase region-or-title)
+                                                         region-or-title))))))
 
 ;;; Finding org-roam files
 (defun org-roam-find-file ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -300,11 +300,17 @@ If not provided, derive the title from the file name."
 
 If PREFIX, downcase the title before insertion."
   (interactive "P")
-  (let* ((completions (mapcar (lambda (file)
+  (let* ((region (and (region-active-p)
+                      ;; following may lose active region, so save it
+                      (cons (region-beginning) (region-end))))
+         (completions (mapcar (lambda (file)
                                 (list (org-roam--get-title-or-slug file)
                                       file))
                               (org-roam--find-all-files)))
-         (title (completing-read "File: " completions))
+         (title (completing-read "File: " completions nil nil
+                                 (when region
+                                   (buffer-substring-no-properties
+                                    (car region) (cdr region)))))
          (absolute-file-path (or (cadr (assoc title completions))
                                  (org-roam--make-new-file-path (org-roam--get-new-id title) t)))
          (current-file-path (-> (or (buffer-base-buffer)
@@ -314,6 +320,9 @@ If PREFIX, downcase the title before insertion."
                                 (file-name-directory))))
     (unless (file-exists-p absolute-file-path)
       (org-roam--make-file absolute-file-path title))
+    (when region ;; Remove previously selected text.
+      (goto-char (car region))
+      (delete-char (- (cdr region) (car region))))
     (insert (format "[[%s][%s]]"
                     (concat "file:" (file-relative-name absolute-file-path
                                                         current-file-path))


### PR DESCRIPTION
###### Motivation for this change
After typing some text, it's easy to highlight part of the text and link it to another page.  Keeping the text the same is preferable to overwriting it with the title of the targeted page.  Uses the existing `competing-read` of the existing insert function and only changes the behavior when text is highlighted.

Addresses #127 