### PR TITLE
(feature): add custom font styling for org-roam links

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -53,6 +53,9 @@ tweaking `org-roam-link-title-format`, for example:
 (setq org-roam-link-title-format "R:%s")
 ```
 
+You may also choose to simply style the link differently, by
+customizing `org-roam-link-face` (`M-x customize-face org-roam-link`).
+
 ## Org-roam Files
 
 These customization options revolve around the Org files created and

--- a/org-roam.el
+++ b/org-roam.el
@@ -138,6 +138,11 @@ If nil, always ask for filename."
   :type 'string
   :group 'org-roam)
 
+(defgroup org-roam-faces nil
+  "Faces used by Org-Roam."
+  :group 'org-roam
+  :group 'faces)
+
 ;;; Polyfills
 ;; These are for functions I use that are only available in newer Emacs
 
@@ -596,9 +601,23 @@ This needs to be quick/infrequent, because this is run at
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))
 
+(defface org-roam-link
+  '((t :inherit org-link))
+  "Face for org-roam link."
+  :group 'org-roam-faces)
+
+(defun org-roam--roam-link-face (path)
+  "Conditional face for org file links.
+
+Applies `org-roam-link-face' if PATH correponds to a Roam file."
+  (if (org-roam--org-roam-file-p path)
+      'org-roam-link
+    'org-link))
+
 (defun org-roam--find-file-hook-function ()
   "Called by `find-file-hook' when `org-roam-mode' is on."
   (when (org-roam--org-roam-file-p)
+    (org-link-set-parameters "file" :face 'org-roam--roam-link-face)
     (add-hook 'post-command-hook #'org-roam--maybe-update-buffer nil t)
     (add-hook 'after-save-hook #'org-roam--update-cache nil t)))
 
@@ -679,6 +698,7 @@ If ARG is `toggle', toggle `org-roam-mode'. Otherwise, behave as if called inter
     ;; Disable local hooks for all org-roam buffers
     (dolist (buf (org-roam--get-roam-buffers))
       (with-current-buffer buf
+        (org-link-set-parameters "file" :face 'org-link)
         (remove-hook 'post-command-hook #'org-roam--maybe-update-buffer t)
         (remove-hook 'after-save-hook #'org-roam--update-cache t))))))
 


### PR DESCRIPTION
This adds 'org-roam-link-face. When org-roam-mode is on, all roam
links take this face. By default, it is exactly the same as 'org-link,
and would require styling.

###### Motivation for this change
Addresses #161 .

Org-roam links can be styled differently from ordinary links. Here's how I style it:

```
(use-package ...
:custom-face
  (org-roam-link ((t (:inherit org-link :foreground "#C991E1"))))
)
```

To give the pink links. I'm not sure if there's a sane default.

![image](https://user-images.githubusercontent.com/1667473/75092805-72674200-55b6-11ea-9c8d-1a7ae28b844b.png)
