### PR TITLE
(bugfix): Use correct padding for modeline lighter

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -679,7 +679,7 @@ if ARG is posiwive, otherwise disable it.
 
 When called from Lisp, enable `org-roam-mode' if ARG is omitted, nil, or positive.
 If ARG is `toggle', toggle `org-roam-mode'. Otherwise, behave as if called interactively."
-  :lighter "Org-Roam "
+  :lighter " Org-Roam"
   :keymap  org-roam-mode-map
   :group 'org-roam
   :require 'org-roam


### PR DESCRIPTION
###### Motivation for this change
Currently duplicate space on the right side and missing padding on the left side:

![modeline](https://user-images.githubusercontent.com/52547/75093123-55fbe300-557f-11ea-9a74-fa1ad0017b49.png)
