### PR TITLE
(bugfix): keep unicode alphanumerics in filename

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -235,11 +235,14 @@ If `ABSOLUTE', return an absolute file-path. Else, return a relative file-path."
 
 (defun org-roam--title-to-slug (title)
   "Convert TITLE to a filename-suitable slug."
-  (let* ((s (s-downcase title))
-         (s (replace-regexp-in-string "[^a-zA-Z0-9_ ]" "" s))
-         (s (s-split " " s))
-         (s (s-join "_" s)))
-    s))
+  (cl-flet ((replace (title pair)
+                     (replace-regexp-in-string (car pair) (cdr pair) title)))
+    (let* ((pairs `(("[^[:alnum:][:digit:]]" . "_")  ;; convert anything not alphanumeric
+                    ("__*" . "_")  ;; remove sequential underscores
+                    ("^_" . "")  ;; remove starting underscore
+                    ("_$" . "")))  ;; remove ending underscore
+           (slug (-reduce-from #'replace title pairs)))
+      (s-downcase slug))))
 
 (defun org-roam--file-name-timestamp-title (title)
   "Return a file name (without extension) for new files.


### PR DESCRIPTION
###### Motivation for this change
When converting a title to something acceptable as a file name, keep Unicode alphanumeric characters.

Ref #158

Example output:
```lisp
(mapcar #'org-roam--title-to-slug
        '("!!!!Org-Roam is great!!!!"
          "Sobre a formação dos planetas"
          "1\\2.3///**"
          "10-2+3=45"))
;; ("org_roam_is_great" "sobre_a_formação_dos_planetas" "1_2_3" "10_2_3_45")
```