### PR TITLE
(feature): support multiple org-roam directories WIP

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -137,12 +137,12 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
         (org-element-property :value kw)))
     :first-match t))
 
-(defun org-roam--build-cache (dirs)
+(defun org-roam--build-cache (dir)
   "Build the org-roam caches in DIR."
   (let ((backward-links (make-hash-table :test #'equal))
         (forward-links (make-hash-table :test #'equal))
         (file-titles (make-hash-table :test #'equal)))
-    (let* ((org-roam-files (mapcan #'org-roam--find-files dirs))
+    (let* ((org-roam-files (org-roam--find-files dir))
            (file-items (mapcar (lambda (file)
                                  (with-temp-buffer
                                    (insert-file-contents file)
@@ -160,9 +160,13 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
             (puthash file title file-titles)))
         org-roam-files))
     (list
+     :directory dir
      :forward forward-links
      :backward backward-links
      :titles file-titles)))
+
+(defun org-roam--build-cache-from-dirs (dirs)
+  (mapcar #' org-roam--build-cache dirs))
 
 (provide 'org-roam-utils)
 

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -137,12 +137,12 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
         (org-element-property :value kw)))
     :first-match t))
 
-(defun org-roam--build-cache (dir)
+(defun org-roam--build-cache (dirs)
   "Build the org-roam caches in DIR."
   (let ((backward-links (make-hash-table :test #'equal))
         (forward-links (make-hash-table :test #'equal))
         (file-titles (make-hash-table :test #'equal)))
-    (let* ((org-roam-files (org-roam--find-files dir))
+    (let* ((org-roam-files (mapcan #'org-roam--find-files dirs))
            (file-items (mapcar (lambda (file)
                                  (with-temp-buffer
                                    (insert-file-contents file)

--- a/org-roam.el
+++ b/org-roam.el
@@ -228,7 +228,8 @@ If called interactively, then PARENTS is non-nil."
              (cdr pair)  ;; Dir from cons by named org-roam directory
            buffer-or-name-or-path))  ;; Must be a path
         (t  ;; Otherwise get the current file path
-         (buffer-file-name))))
+         (buffer-file-name (or (buffer-base-buffer)
+                                    (current-buffer))))))
 
 (defun org-roam--get-title-from-cache (file)
   "Return title of `FILE' from the cache."

--- a/org-roam.el
+++ b/org-roam.el
@@ -383,14 +383,17 @@ If PREFIX, downcase the title before insertion."
 (defun org-roam-find-file (&optional buffer-or-name-or-path)
   "Find and open an org-roam file."
   (interactive)
-  (let* ((completions (mapcar (lambda (file)
+  (let* ((context-path (and (eq (type-of org-roam-directory) 'cons)
+                            (or (org-roam--get-context-path buffer-or-name-or-path)
+                                (completing-read "Pick org-roam name: " org-roam-directory))))
+         (completions (mapcar (lambda (file)
                                 (list (org-roam--get-title-or-slug file) file))
-                              (org-roam--find-all-files buffer-or-name-or-path)))
+                              (org-roam--find-all-files context-path)))
          (title-or-slug (completing-read "File: " completions))
          (absolute-file-path (or (cadr (assoc title-or-slug completions))
                                  (org-roam--make-new-file-path
                                   (org-roam--get-new-id title-or-slug) t
-                                  buffer-or-name-or-path))))
+                                  context-path))))
     (unless (file-exists-p absolute-file-path)
       (org-roam--make-file absolute-file-path title-or-slug))
     (find-file absolute-file-path)))
@@ -402,7 +405,7 @@ directory if there are multiple directories."
   (cl-typecase org-roam-directory
     (string (org-roam-find-file))
     (cons
-     (when-let ((name (completing-read "Name: " org-roam-directory)))
+     (when-let ((name (completing-read "Pick org-roam name: " org-roam-directory)))
        (org-roam-find-file name)))))
 
 (defun org-roam--get-roam-buffers ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -389,7 +389,8 @@ If PREFIX, downcase the title before insertion."
          (title-or-slug (completing-read "File: " completions))
          (absolute-file-path (or (cadr (assoc title-or-slug completions))
                                  (org-roam--make-new-file-path
-                                  (org-roam--get-new-id title-or-slug) t))))
+                                  (org-roam--get-new-id title-or-slug) t
+                                  buffer-or-name-or-path))))
     (unless (file-exists-p absolute-file-path)
       (org-roam--make-file absolute-file-path title-or-slug))
     (find-file absolute-file-path)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -196,7 +196,7 @@ If called interactively, then PARENTS is non-nil."
                         (buffer-file-name (current-buffer))))
               ((org-roam--org-file-p path))
               (true-path (file-truename path)))
-    (typecase org-roam-directory
+    (cl-typecase org-roam-directory
       (string (f-descendant-of-p true-path
                                  (file-truename org-roam-directory)))
       (cons (--any (f-descendant-of-p true-path (file-truename (cdr it)))
@@ -204,7 +204,7 @@ If called interactively, then PARENTS is non-nil."
 
 (defun org-roam-get-directory (&optional buffer-or-name-or-path)
   "Get the org-roam directory best matching the current context."
-  (typecase org-roam-directory
+  (cl-typecase org-roam-directory
     ;; When string, always the same directory
     (string org-roam-directory)
     (cons ;; If cons, we must determine the directory based on context
@@ -397,7 +397,7 @@ If PREFIX, downcase the title before insertion."
   "Find and open an org-roam file, first selecting org-roam
 directory if there are multiple directories."
   (interactive)
-  (typecase org-roam-directory
+  (cl-typecase org-roam-directory
     (string (org-roam-find-file))
     (cons
      (when-let ((name (completing-read "Name: " org-roam-directory)))
@@ -436,7 +436,7 @@ directory if there are multiple directories."
   (interactive)
   (unless (and (processp org-roam--ongoing-async-build)
                (not (async-ready org-roam--ongoing-async-build)))
-    (let ((dirs (typecase org-roam-directory
+    (let ((dirs (cl-typecase org-roam-directory
                   (string (list org-roam-directory))
                   (cons (mapcar #'cdr org-roam-directory)))))
       (setq org-roam--ongoing-async-build

--- a/org-roam.el
+++ b/org-roam.el
@@ -413,7 +413,7 @@ If PREFIX, downcase the title before insertion."
                               (org-roam--find-all-files context-path)))
          (title-or-slug (completing-read "File: " completions))
          (absolute-file-path (or (cadr (assoc title-or-slug completions))
-                                 (org-roam--make-new-file title-or-slug context-path))))
+                                 (org-roam--make-new-file title-or-slug))))
     (find-file absolute-file-path)))
 
 (defun org-roam-find-file-pick-dir ()

--- a/tests/roam-files-multi/mf1.org
+++ b/tests/roam-files-multi/mf1.org
@@ -1,0 +1,7 @@
+#+TITLE: Multi-File 1
+
+link to [[file:nested/mf1.org][Nested Multi-File 1]]
+link to [[file:mf2.org][Multi-File 2]]
+
+Arbitrary [[https://google.com][HTML]] link
+Arbitrary text

--- a/tests/roam-files-multi/mf2.org
+++ b/tests/roam-files-multi/mf2.org
@@ -1,0 +1,3 @@
+#+TITLE: Multi-File 2
+
+This file has no links.

--- a/tests/roam-files-multi/mf3.org
+++ b/tests/roam-files-multi/mf3.org
@@ -1,0 +1,5 @@
+#+TITLE: Multi-File 3
+
+This file has a link to an file with no title.
+
+[[file:multi-no-title.org][multi-no-title]]

--- a/tests/roam-files-multi/multi-no-title.org
+++ b/tests/roam-files-multi/multi-no-title.org
@@ -1,0 +1,1 @@
+no title in this file :O

--- a/tests/roam-files-multi/nested/mf1.org
+++ b/tests/roam-files-multi/nested/mf1.org
@@ -1,0 +1,4 @@
+#+TITLE: Nested Multi-File 1
+
+Link to [[file:mf2.org][Nested Multi-File 2]]
+Link to [[file:../mf1.org][Mulit-File 1]]

--- a/tests/roam-files-multi/nested/mf2.org
+++ b/tests/roam-files-multi/nested/mf2.org
@@ -1,0 +1,3 @@
+#+TITLE: Nested Multi-File 2
+
+Link to [[file:mf1.org][Nested Multi-File 1]]

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -52,7 +52,7 @@
 
 (defun org-roam--test-build-cache ()
   "Builds the caches synchronously."
-  (let ((cache (org-roam--build-cache org-roam-directory)))
+  (let ((cache (org-roam--build-cache (list org-roam-directory))))
     (setq org-roam-forward-links-cache (plist-get cache :forward))
     (setq org-roam-backward-links-cache (plist-get cache :backward))
     (setq org-roam-titles-cache (plist-get cache :titles))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -73,39 +73,42 @@
     (setq org-roam-mute-cache-build t))
   (org-roam-mode +1))
 
-(defun org-roam--test-build-cache ()
+(defun org-roam--test-build-cache (&optional context)
   "Builds the caches synchronously."
-  (let ((cache (org-roam--build-cache (cl-typecase org-roam-directory
-                                        (string (list org-roam-directory))
-                                        (cons (mapcar #'cdr org-roam-directory))))))
-    (setq org-roam-forward-links-cache (plist-get cache :forward))
-    (setq org-roam-backward-links-cache (plist-get cache :backward))
-    (setq org-roam-titles-cache (plist-get cache :titles))
-    (setq org-roam-cache-initialized t)))
+  (let* ((dir (org-roam-get-directory context))
+         (cache (org-roam--build-cache dir)))
+    (org-roam--set-context-cache
+     dir
+     (org-roam-cache :initialized t
+                     :forward-links (plist-get cache :forward)
+                     :backward-links (plist-get cache :backward)
+                     :titles (plist-get cache :titles)))))
 
 ;;; Tests
 (describe "org-roam--build-cache-async"
           (it "initializes correctly"
               (org-roam--test-init)
-              (expect org-roam-cache-initialized :to-be nil)
-              (expect (hash-table-count org-roam-forward-links-cache) :to-be 0)
-              (expect (hash-table-count org-roam-backward-links-cache) :to-be 0)
-              (expect (hash-table-count org-roam-titles-cache) :to-be 0)
+              (expect (org-roam-cache-initialized) :to-be nil)
+              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam-titles-cache)) :to-be 0)
 
               (org-roam--build-cache-async)
               (sleep-for 3) ;; Because it's async
 
               ;; Caches should be populated
-              (expect org-roam-cache-initialized :to-be t)
-              (expect (hash-table-count org-roam-forward-links-cache) :to-be 4)
-              (expect (hash-table-count org-roam-backward-links-cache) :to-be 5)
-              (expect (hash-table-count org-roam-titles-cache) :to-be 5)
+              (expect (org-roam-cache-initialized) :to-be t)
+              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
+              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
+              (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
 
               ;; Forward cache
-              (let ((f1 (gethash (abs-path "f1.org") org-roam-forward-links-cache))
-                    (f2 (gethash (abs-path "f2.org") org-roam-forward-links-cache))
-                    (nested-f1 (gethash (abs-path "nested/f1.org") org-roam-forward-links-cache))
-                    (nested-f2 (gethash (abs-path "nested/f2.org") org-roam-forward-links-cache))
+              (let ((f1 (gethash (abs-path "f1.org") (org-roam-forward-links-cache)))
+                    (f2 (gethash (abs-path "f2.org") (org-roam-forward-links-cache)))
+                    (nested-f1 (gethash (abs-path "nested/f1.org")
+                                        (org-roam-forward-links-cache)))
+                    (nested-f2 (gethash (abs-path "nested/f2.org")
+                                        (org-roam-forward-links-cache)))
                     (expected-f1 (list (abs-path "nested/f1.org")
                                        (abs-path "f2.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -118,10 +121,14 @@
                 (expect nested-f2 :to-have-same-items-as expected-nested-f2))
 
               ;; Backward cache
-              (let ((f1 (hash-table-keys (gethash (abs-path "f1.org") org-roam-backward-links-cache)))
-                    (f2 (hash-table-keys (gethash (abs-path "f2.org") org-roam-backward-links-cache)))
-                    (nested-f1 (hash-table-keys(gethash (abs-path "nested/f1.org") org-roam-backward-links-cache)))
-                    (nested-f2 (hash-table-keys (gethash (abs-path "nested/f2.org") org-roam-backward-links-cache)))
+              (let ((f1 (hash-table-keys (gethash (abs-path "f1.org")
+                                                  (org-roam-backward-links-cache))))
+                    (f2 (hash-table-keys (gethash (abs-path "f2.org")
+                                                  (org-roam-backward-links-cache))))
+                    (nested-f1 (hash-table-keys(gethash (abs-path "nested/f1.org")
+                                                        (org-roam-backward-links-cache))))
+                    (nested-f2 (hash-table-keys (gethash (abs-path "nested/f2.org")
+                                                         (org-roam-backward-links-cache))))
                     (expected-f1 (list (abs-path "nested/f1.org")))
                     (expected-f2 (list (abs-path "f1.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -133,39 +140,39 @@
                 (expect nested-f2 :to-have-same-items-as expected-nested-f2))
 
               ;; Titles Cache
-              (expect (gethash (abs-path "f1.org") org-roam-titles-cache) :to-equal "File 1")
-              (expect (gethash (abs-path "f2.org") org-roam-titles-cache) :to-equal "File 2")
-              (expect (gethash (abs-path "nested/f1.org") org-roam-titles-cache) :to-equal "Nested File 1")
-              (expect (gethash (abs-path "nested/f2.org") org-roam-titles-cache) :to-equal "Nested File 2")
-              (expect (gethash (abs-path "no-title.org") org-roam-titles-cache) :to-be nil)))
+              (expect (gethash (abs-path "f1.org") (org-roam-titles-cache)) :to-equal "File 1")
+              (expect (gethash (abs-path "f2.org") (org-roam-titles-cache)) :to-equal "File 2")
+              (expect (gethash (abs-path "nested/f1.org") (org-roam-titles-cache)) :to-equal "Nested File 1")
+              (expect (gethash (abs-path "nested/f2.org") (org-roam-titles-cache)) :to-equal "Nested File 2")
+              (expect (gethash (abs-path "no-title.org") (org-roam-titles-cache)) :to-be nil)))
 
 (describe "org-roam--build-cache-async-multi"
           (it "initializes correctly"
               (org-roam--clear-cache)
               (org-roam--test-multi-init)
-              (expect org-roam-cache-initialized :to-be nil)
-              (expect (hash-table-count org-roam-forward-links-cache) :to-be 0)
-              (expect (hash-table-count org-roam-backward-links-cache) :to-be 0)
-              (expect (hash-table-count org-roam-titles-cache) :to-be 0)
+              (expect (org-roam-cache-initialized) :to-be nil)
+              (expect (hash-table-count (org-roam-forward-links-cache "public")) :to-be 0)
+              (expect (hash-table-count (org-roam-backward-links-cache "public")) :to-be 0)
+              (expect (hash-table-count (org-roam-titles-cache "public")) :to-be 0)
 
               (org-roam--build-cache-async)
               (sleep-for 3) ;; Because it's async
 
               ;; Caches should be populated
-              (expect org-roam-cache-initialized :to-be t)
-              (expect (hash-table-count org-roam-forward-links-cache) :to-be 8)
-              (expect (hash-table-count org-roam-backward-links-cache) :to-be 10)
-              (expect (hash-table-count org-roam-titles-cache) :to-be 10)
+              (expect (org-roam-cache-initialized "public") :to-be t)
+              (expect (hash-table-count (org-roam-forward-links-cache "public")) :to-be 4)
+              (expect (hash-table-count (org-roam-backward-links-cache "public")) :to-be 5)
+              (expect (hash-table-count (org-roam-titles-cache "public")) :to-be 5)
 
               ;; Forward cache
               (let ((f1 (gethash (multi-abs-path "public" "f1.org")
-                                 org-roam-forward-links-cache))
+                                 (org-roam-forward-links-cache)))
                     (f2 (gethash (multi-abs-path "public" "f2.org")
-                                 org-roam-forward-links-cache))
+                                 (org-roam-forward-links-cache)))
                     (nested-f1 (gethash (multi-abs-path "public" "nested/f1.org")
-                                        org-roam-forward-links-cache))
+                                        (org-roam-forward-links-cache)))
                     (nested-f2 (gethash (multi-abs-path "public" "nested/f2.org")
-                                        org-roam-forward-links-cache))
+                                        (org-roam-forward-links-cache)))
                     (expected-f1 (list (multi-abs-path "public" "nested/f1.org")
                                        (multi-abs-path "public" "f2.org")))
                     (expected-nested-f1 (list (multi-abs-path "public" "nested/f2.org")
@@ -179,15 +186,15 @@
 
               ;; Backward cache
               (let ((f1 (hash-table-keys (gethash (multi-abs-path "public" "f1.org")
-                                                  org-roam-backward-links-cache)))
+                                                  (org-roam-backward-links-cache "public"))))
                     (f2 (hash-table-keys (gethash (multi-abs-path "public" "f2.org")
-                                                  org-roam-backward-links-cache)))
+                                                  (org-roam-backward-links-cache "public"))))
                     (nested-f1 (hash-table-keys
                                 (gethash (multi-abs-path "public" "nested/f1.org")
-                                         org-roam-backward-links-cache)))
+                                         (org-roam-backward-links-cache "public"))))
                     (nested-f2 (hash-table-keys
                                 (gethash (multi-abs-path "public" "nested/f2.org")
-                                         org-roam-backward-links-cache)))
+                                         (org-roam-backward-links-cache "public"))))
                     (expected-f1 (list (multi-abs-path "public" "nested/f1.org")))
                     (expected-f2 (list (multi-abs-path "public" "f1.org")))
                     (expected-nested-f1 (list (multi-abs-path "public" "nested/f2.org")
@@ -200,27 +207,33 @@
 
               ;; Titles Cache
               (expect (gethash (multi-abs-path "public" "f1.org")
-                               org-roam-titles-cache) :to-equal "File 1")
+                               (org-roam-titles-cache "public")) :to-equal "File 1")
               (expect (gethash (multi-abs-path "public" "f2.org")
-                               org-roam-titles-cache) :to-equal "File 2")
+                               (org-roam-titles-cache "public")) :to-equal "File 2")
               (expect (gethash (multi-abs-path "public" "nested/f1.org")
-                               org-roam-titles-cache) :to-equal "Nested File 1")
+                               (org-roam-titles-cache "public")) :to-equal "Nested File 1")
               (expect (gethash (multi-abs-path "public" "nested/f2.org")
-                               org-roam-titles-cache) :to-equal "Nested File 2")
+                               (org-roam-titles-cache "public")) :to-equal "Nested File 2")
               (expect (gethash (multi-abs-path "public" "no-title.org")
-                               org-roam-titles-cache) :to-be nil)
+                               (org-roam-titles-cache "public")) :to-be nil)
 
               ;; Multi
 
+              ;; Caches should be populated
+              (expect (org-roam-cache-initialized "personal") :to-be t)
+              (expect (hash-table-count (org-roam-forward-links-cache "personal")) :to-be 4)
+              (expect (hash-table-count (org-roam-backward-links-cache "personal")) :to-be 5)
+              (expect (hash-table-count (org-roam-titles-cache "personal")) :to-be 5)
+
               ;; Forward cache
               (let ((mf1 (gethash (multi-abs-path "personal" "mf1.org")
-                                 org-roam-forward-links-cache))
+                                  (org-roam-forward-links-cache "personal")))
                     (mf2 (gethash (multi-abs-path "personal" "mf2.org")
-                                 org-roam-forward-links-cache))
+                                  (org-roam-forward-links-cache "personal")))
                     (nested-mf1 (gethash (multi-abs-path "personal" "nested/mf1.org")
-                                        org-roam-forward-links-cache))
+                                         (org-roam-forward-links-cache "personal")))
                     (nested-mf2 (gethash (multi-abs-path "personal" "nested/mf2.org")
-                                        org-roam-forward-links-cache))
+                                         (org-roam-forward-links-cache "personal")))
                     (expected-mf1 (list (multi-abs-path "personal" "nested/mf1.org")
                                        (multi-abs-path "personal" "mf2.org")))
                     (expected-nested-mf1 (list (multi-abs-path "personal" "nested/mf2.org")
@@ -233,16 +246,18 @@
                 (expect nested-mf2 :to-have-same-items-as expected-nested-mf2))
 
               ;; Backward cache
-              (let ((mf1 (hash-table-keys (gethash (multi-abs-path "personal" "mf1.org")
-                                                  org-roam-backward-links-cache)))
-                    (mf2 (hash-table-keys (gethash (multi-abs-path "personal" "mf2.org")
-                                                  org-roam-backward-links-cache)))
+              (let ((mf1 (hash-table-keys
+                          (gethash (multi-abs-path "personal" "mf1.org")
+                                   (org-roam-backward-links-cache "personal"))))
+                    (mf2 (hash-table-keys
+                          (gethash (multi-abs-path "personal" "mf2.org")
+                                   (org-roam-backward-links-cache "personal"))))
                     (nested-mf1 (hash-table-keys
                                 (gethash (multi-abs-path "personal" "nested/mf1.org")
-                                         org-roam-backward-links-cache)))
+                                         (org-roam-backward-links-cache "personal"))))
                     (nested-mf2 (hash-table-keys
                                 (gethash (multi-abs-path "personal" "nested/mf2.org")
-                                         org-roam-backward-links-cache)))
+                                         (org-roam-backward-links-cache "personal"))))
                     (expected-mf1 (list (multi-abs-path "personal" "nested/mf1.org")))
                     (expected-mf2 (list (multi-abs-path "personal" "mf1.org")))
                     (expected-nested-mf1 (list (multi-abs-path "personal" "nested/mf2.org")
@@ -255,15 +270,20 @@
 
               ;; Titles Cache
               (expect (gethash (multi-abs-path "personal" "mf1.org")
-                               org-roam-titles-cache) :to-equal "Multi-File 1")
+                               (org-roam-titles-cache "personal"))
+                      :to-equal "Multi-File 1")
               (expect (gethash (multi-abs-path "personal" "mf2.org")
-                               org-roam-titles-cache) :to-equal "Multi-File 2")
+                               (org-roam-titles-cache "personal"))
+                      :to-equal "Multi-File 2")
               (expect (gethash (multi-abs-path "personal" "nested/mf1.org")
-                               org-roam-titles-cache) :to-equal "Nested Multi-File 1")
+                               (org-roam-titles-cache "personal"))
+                      :to-equal "Nested Multi-File 1")
               (expect (gethash (multi-abs-path "personal" "nested/mf2.org")
-                               org-roam-titles-cache) :to-equal "Nested Multi-File 2")
+                               (org-roam-titles-cache "personal"))
+                      :to-equal "Nested Multi-File 2")
               (expect (gethash (multi-abs-path "personal" "no-title.org")
-                               org-roam-titles-cache) :to-be nil)))
+                               (org-roam-titles-cache "personal"))
+                      :to-be nil)))
 
 (describe "org-roam-insert"
           (before-each
@@ -307,7 +327,8 @@
           (before-each
            (org-roam--test-multi-init)
            (org-roam--clear-cache)
-           (org-roam--test-build-cache))
+           (org-roam--test-build-cache "personal")
+           (org-roam--test-build-cache "public"))
 
           ;; public
 
@@ -387,16 +408,16 @@
               (rename-file (abs-path "f1.org")
                            (abs-path "new_f1.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (abs-path "f1.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (gethash (abs-path "f1.org")  (org-roam-forward-links-cache)) :to-be nil)
+              (expect (->> (org-roam-backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (hash-table-keys)
                            (member (abs-path "f1.org"))) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (abs-path "new_f1.org"))) :not :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (abs-path "new_f1.org"))
                            (member (abs-path "nested/f1.org"))) :not :to-be nil)
               ;; Links are updated
@@ -409,8 +430,8 @@
               (rename-file (abs-path "f1.org")
                            (abs-path "f1 with spaces.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (abs-path "f1.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (gethash (abs-path "f1.org")  (org-roam-forward-links-cache)) :to-be nil)
+              (expect (->> (org-roam-backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (hash-table-keys)
                            (member (abs-path "f1.org"))) :to-be nil)
@@ -423,14 +444,15 @@
               (rename-file (abs-path "no-title.org")
                            (abs-path "meaningful-title.org"))
               ;; File has no forward links
-              (expect (gethash (abs-path "no-title.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (gethash (abs-path "meaningful-title.org")  org-roam-forward-links-cache) :to-be nil)
+              (expect (gethash (abs-path "no-title.org")  (org-roam-forward-links-cache)) :to-be nil)
+              (expect (gethash (abs-path "meaningful-title.org")
+                               (org-roam-forward-links-cache)) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (abs-path "f3.org"))
                            (member (abs-path "no-title.org"))) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (abs-path "f3.org"))
                            (member (abs-path "meaningful-title.org"))) :not :to-be nil)
 
@@ -443,22 +465,24 @@
           (before-each
            (org-roam--test-multi-init)
            (org-roam--clear-cache)
-           (org-roam--test-build-cache))
+           (org-roam--test-build-cache "personal")
+           (org-roam--test-build-cache "public"))
 
           (it "f1 -> new_f1"
               (rename-file (multi-abs-path "public" "f1.org")
                            (multi-abs-path "public" "new_f1.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (multi-abs-path "public" "f1.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (gethash (multi-abs-path "public" "f1.org")
+                               (org-roam-forward-links-cache "public")) :to-be nil)
+              (expect (->> (org-roam-backward-links-cache "public")
                            (gethash (multi-abs-path "public" "nested/f1.org"))
                            (hash-table-keys)
                            (member (multi-abs-path "public" "f1.org"))) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache "public")
                            (gethash (multi-abs-path "public" "new_f1.org"))) :not :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache "public")
                            (gethash (multi-abs-path "public" "new_f1.org"))
                            (member (multi-abs-path "public" "nested/f1.org"))) :not :to-be nil)
               ;; Links are updated
@@ -471,8 +495,9 @@
               (rename-file (multi-abs-path "public" "f1.org")
                            (multi-abs-path "public" "f1 with spaces.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (multi-abs-path "public" "f1.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (gethash (multi-abs-path "public" "f1.org")
+                               (org-roam-forward-links-cache)) :to-be nil)
+              (expect (->> (org-roam-backward-links-cache "public")
                            (gethash (multi-abs-path "public" "nested/f1.org"))
                            (hash-table-keys)
                            (member (multi-abs-path "public" "f1.org"))) :to-be nil)
@@ -485,14 +510,16 @@
               (rename-file (multi-abs-path "public" "no-title.org")
                            (multi-abs-path "public" "meaningful-title.org"))
               ;; File has no forward links
-              (expect (gethash (multi-abs-path "public" "no-title.org")  org-roam-forward-links-cache) :to-be nil)
-              (expect (gethash (multi-abs-path "public" "meaningful-title.org")  org-roam-forward-links-cache) :to-be nil)
+              (expect (gethash (multi-abs-path "public" "no-title.org")
+                               (org-roam-forward-links-cache)) :to-be nil)
+              (expect (gethash (multi-abs-path "public" "meaningful-title.org")
+                               (org-roam-forward-links-cache)) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (multi-abs-path "public" "f3.org"))
                            (member (multi-abs-path "public" "no-title.org"))) :to-be nil)
 
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (multi-abs-path "public" "f3.org"))
                            (member (multi-abs-path "public" "meaningful-title.org"))) :not :to-be nil)
 
@@ -508,12 +535,12 @@
            (org-roam--test-build-cache))
           (it "delete f1"
               (delete-file (abs-path "f1.org"))
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache)
                            (gethash (abs-path "f1.org"))) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (->> (org-roam-backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (gethash (abs-path "f1.org"))) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (->> (org-roam-backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (gethash (abs-path "nested/f2.org"))) :not :to-be nil)))
 
@@ -521,14 +548,16 @@
           (before-each
            (org-roam--test-multi-init)
            (org-roam--clear-cache)
-           (org-roam--test-build-cache))
+           (org-roam--test-build-cache "personal")
+           (org-roam--test-build-cache "public"))
+
           (it "delete f1"
               (delete-file (multi-abs-path "public" "f1.org"))
-              (expect (->> org-roam-forward-links-cache
+              (expect (->> (org-roam-forward-links-cache "public")
                            (gethash (multi-abs-path "public" "f1.org"))) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (->> (org-roam-backward-links-cache "public")
                            (gethash (multi-abs-path "public" "nested/f1.org"))
                            (gethash (multi-abs-path "public" "f1.org"))) :to-be nil)
-              (expect (->> org-roam-backward-links-cache
+              (expect (->> (org-roam-backward-links-cache "public")
                            (gethash (multi-abs-path "public" "nested/f1.org"))
                            (gethash (multi-abs-path "public" "nested/f2.org"))) :not :to-be nil)))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -78,11 +78,11 @@
   (let* ((dir (org-roam-get-directory context))
          (cache (org-roam--build-cache dir)))
     (org-roam--set-context-cache
-     dir
      (org-roam-cache :initialized t
                      :forward-links (plist-get cache :forward)
                      :backward-links (plist-get cache :backward)
-                     :titles (plist-get cache :titles)))))
+                     :titles (plist-get cache :titles))
+     dir)))
 
 ;;; Tests
 (describe "org-roam--build-cache-async"


### PR DESCRIPTION
ref #80

Adds functionality to org-roam-directory to permit multiple directories.  Which directory is used it based on context.  When there is insufficient context, the first directory is used. (Maybe it would be better to allow the user to pick when there isn't sufficient context, or make it customizable.)   There is a new command org-roam-find-file-pick-dir that uses completing read to choose the directory to use first.

###### Motivation for this change
I have multiple contexts that I use org-roam in.  I would like to use org-roam concurrently with my various repositories of org files.  At the same time, I want to keep them separate, as work files shouldn't link to my personal files and vice-versa.

###### Note
This is a big change, I've tested basic functionality and haven't found anything yet that isn't working, but I'd be wary to merge it in without multiple people testing out their own use cases.
