### PR TITLE
WIP (feature): Add support for unlinked references

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -182,13 +182,6 @@ If called interactively, then PARENTS is non-nil."
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")
 
-(defcustom org-roam-directory (expand-file-name "~/org-roam/")
-  "Path to Org-roam files.
-
-All Org files, at any level of nesting, is considered part of the Org-roam."
-  :type 'directory
-  :group 'org-roam)
-
 (defcustom org-roam-unwanted-regexps
   (list
    org-babel-src-block-regexp
@@ -524,9 +517,11 @@ Bindings:
 
 (defun org-roam--unlinked-regexp (file-path)
   (let* ((buffer-title (org-roam--get-title-or-slug file-path)))
-    (rx-to-string `(or ,buffer-title
+    (rx-to-string `(: word-boundary
+                      (or ,buffer-title
                        ,(downcase buffer-title)
-                       ,(file-name-base file-path)))))
+                       ,(file-name-base file-path))
+                      word-boundary))))
 
 
 (defun org-roam--find-unlinked-references (file-path)

--- a/org-roam.el
+++ b/org-roam.el
@@ -530,7 +530,6 @@ Bindings:
                        ,(file-name-base file-path))
                       word-boundary))))
 
-
 (defun org-roam--find-unlinked-references (file-path)
   (let* ((match-regexp (org-roam--unlinked-regexp file-path))
          (find-func (lambda (other-file)
@@ -625,7 +624,7 @@ Bindings:
                                                'text-start (plist-get match :point)
                                                'text-end (plist-get match :end)
                                                'file-from-point (plist-get match :point))))
-                      (insert (format "%s\n\n" content (plist-get match :point)))))))
+                      (insert (format "%s\n\n" content))))))
             (insert "\n\n* No unlinked references!\n"))))
       (read-only-mode 1))))
 


### PR DESCRIPTION
This PR follows the motivation of #31 to add unlinked references to the org roam buffer. This also allows to covert the unlinked reference into a link by clicking on the entry. Some notes:

- The files are read on `org-roam-update`, which might be underisable. This can easily be converted to use a cache similar to backlinks.
- There is a list of `org-roam-unwanted-regexps` which can be modified for a user's workflow. An example included would be to ignore source blocks.
- A particular regexp is matched against the file, which includes the file name, the title and the lower case title (separated by word boundary). Suggestions or omissions very welcome.
- Format of the unlinked references (including count) mirror the backlink behaviour.
- Regex is used throughout. There could be better solutions. There are already some issues with getting the unformatted point vs the formatted point. There may be an easy solution to this to accomodate any possible formatting.