### PR TITLE
Fixed broken markdown src block

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -122,7 +122,7 @@ you can use the following template:
 (setq org-roam-templates
     (list (list "default" (list :file #'my-org-roam-no-timestamp-in-title
 :content "#+TITLE: ${title}"))))
-````
+```
 
 ### Autopopulating Titles
 


### PR DESCRIPTION
###### Motivation for this change
One of the recent changes looks to have broken the docs on [this](https://org-roam.readthedocs.io/en/latest/configuration/) page by inserting one too many back-ticks in the closing part of the src block. This PR just removes one of the back-ticks.