### PR TITLE
Allow dir locals override dir

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -160,6 +160,7 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
             (puthash file title file-titles)))
         org-roam-files))
     (list
+     :directory dir
      :forward forward-links
      :backward backward-links
      :titles file-titles)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -648,7 +648,8 @@ This needs to be quick/infrequent, because this is run at
     (when (and (or redisplay
                    (not (eq org-roam--current-buffer buffer)))
                (eq 'visible (org-roam--current-visibility))
-               (buffer-local-value 'buffer-file-truename buffer))
+               (buffer-local-value 'buffer-file-truename buffer)
+               (org-roam-cache-initialized))
       (setq org-roam--current-buffer buffer)
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))
@@ -670,6 +671,8 @@ Applies `org-roam-link-face' if PATH correponds to a Roam file."
   "Called by `find-file-hook' when `org-roam-mode' is on."
   (when (org-roam--org-roam-file-p)
     (setq org-roam-last-window (get-buffer-window))
+    (add-hook 'post-command-hook #'org-roam--maybe-update-buffer nil t)
+    (add-hook 'after-save-hook #'org-roam--update-cache nil t)
     (if (org-roam-cache-initialized)
         (org-roam--setup-found-file)
       (org-roam--build-cache-async
@@ -681,8 +684,6 @@ Applies `org-roam-link-face' if PATH correponds to a Roam file."
 (defun org-roam--setup-found-file ()
   "Setup a buffer recognized via the \"find-file-hook\"."
   (org-link-set-parameters "file" :face 'org-roam--roam-link-face)
-  (add-hook 'post-command-hook #'org-roam--maybe-update-buffer nil t)
-  (add-hook 'after-save-hook #'org-roam--update-cache nil t)
   (org-roam--maybe-update-buffer :redisplay nil))
 
 (defvar org-roam-mode-map

--- a/org-roam.el
+++ b/org-roam.el
@@ -648,8 +648,8 @@ This needs to be quick/infrequent, because this is run at
     (when (and (or redisplay
                    (not (eq org-roam--current-buffer buffer)))
                (eq 'visible (org-roam--current-visibility))
-               (buffer-local-value 'buffer-file-truename buffer)
-               (org-roam-cache-initialized))
+               (org-roam-cache-initialized)
+               (buffer-local-value 'buffer-file-truename buffer))
       (setq org-roam--current-buffer buffer)
       (org-roam-update (expand-file-name
                         (buffer-local-value 'buffer-file-truename buffer))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -184,13 +184,18 @@ If called interactively, then PARENTS is non-nil."
   "The list of cache separated by directory.")
 
 ;;; Utilities
+(defun org-roam-directory-normalized ()
+  "Get the org-roam-directory normalized so that it can be used
+as a unique key."
+  (s-chop-suffix "/" (file-truename org-roam-directory)))
+
 (defmacro org-roam--get-local (name)
   "Get a variable that is local to the current org-roam-directory."
-  `(alist-get (expand-file-name org-roam-directory) ,name nil nil #'equal))
+  `(alist-get (org-roam-directory-normalized) ,name nil nil #'equal))
 
 (defmacro org-roam--set-local (name value)
   "Set a variable that is local to the current org-roam-directory."
-  `(setf (alist-get (expand-file-name org-roam-directory) ,name nil nil #'equal)
+  `(setf (alist-get (org-roam-directory-normalized) ,name nil nil #'equal)
          ,value))
 
 (defun org-roam--get-directory-cache ()
@@ -198,13 +203,11 @@ If called interactively, then PARENTS is non-nil."
   (let* ((cache (org-roam--get-local org-roam--cache)))
     (if cache
         cache
-      (let ((new-cache (org-roam--default-cache)))
-        (org-roam--set-local org-roam--cache new-cache)
-        new-cache))))
+      (org-roam--set-local org-roam--cache (org-roam--default-cache)))))
 
 (defun org-roam--set-directory-cache (data)
   "Set the cache object for the current org-roam-directory."
-  (setf (alist-get (expand-file-name org-roam-directory)
+  (setf (alist-get (org-roam-directory-normalized)
                    org-roam--cache nil nil #'equal) data))
 
 (defun org-roam-cache-initialized ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -187,7 +187,7 @@ If called interactively, then PARENTS is non-nil."
 (defun org-roam-directory-normalized ()
   "Get the org-roam-directory normalized so that it can be used
 as a unique key."
-  (s-chop-suffix "/" (file-truename org-roam-directory)))
+  (directory-file-name (file-truename org-roam-directory)))
 
 (defmacro org-roam--get-local (name)
   "Get a variable that is local to the current org-roam-directory."

--- a/org-roam.el
+++ b/org-roam.el
@@ -203,7 +203,9 @@ as a unique key."
   (let* ((cache (org-roam--get-local org-roam--cache)))
     (if cache
         cache
-      (org-roam--set-local org-roam--cache (org-roam--default-cache)))))
+      (let ((new-cache (org-roam--default-cache)))
+        (org-roam--set-local org-roam--cache new-cache)
+        new-cache))))
 
 (defun org-roam--set-directory-cache (data)
   "Set the cache object for the current org-roam-directory."

--- a/tests/roam-files-multi/mf1.org
+++ b/tests/roam-files-multi/mf1.org
@@ -1,0 +1,7 @@
+#+TITLE: Multi-File 1
+
+link to [[file:nested/mf1.org][Nested Multi-File 1]]
+link to [[file:mf2.org][Multi-File 2]]
+
+Arbitrary [[https://google.com][HTML]] link
+Arbitrary text

--- a/tests/roam-files-multi/mf2.org
+++ b/tests/roam-files-multi/mf2.org
@@ -1,0 +1,3 @@
+#+TITLE: Multi-File 2
+
+This file has no links.

--- a/tests/roam-files-multi/mf3.org
+++ b/tests/roam-files-multi/mf3.org
@@ -1,0 +1,5 @@
+#+TITLE: Multi-File 3
+
+This file has a link to an file with no title.
+
+[[file:multi-no-title.org][multi-no-title]]

--- a/tests/roam-files-multi/multi-no-title.org
+++ b/tests/roam-files-multi/multi-no-title.org
@@ -1,0 +1,1 @@
+no title in this file :O

--- a/tests/roam-files-multi/nested/mf1.org
+++ b/tests/roam-files-multi/nested/mf1.org
@@ -1,0 +1,4 @@
+#+TITLE: Nested Multi-File 1
+
+Link to [[file:mf2.org][Nested Multi-File 2]]
+Link to [[file:../mf1.org][Mulit-File 1]]

--- a/tests/roam-files-multi/nested/mf2.org
+++ b/tests/roam-files-multi/nested/mf2.org
@@ -1,0 +1,3 @@
+#+TITLE: Nested Multi-File 2
+
+Link to [[file:mf1.org][Nested Multi-File 1]]

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -42,11 +42,26 @@
 (defvar org-roam--tests-directory (file-truename (concat default-directory "tests/roam-files"))
   "Directory containing org-roam test org files.")
 
+(defvar org-roam--tests-multi (file-truename (concat default-directory "tests/roam-files-multi"))
+  "Directory containing org-roam test org files.")
+
 (defun org-roam--test-init ()
   (let ((original-dir org-roam--tests-directory)
         (new-dir (expand-file-name (make-temp-name "org-roam") temporary-file-directory)))
     (copy-directory original-dir new-dir)
     (setq org-roam-directory new-dir)
+    (setq org-roam-mute-cache-build t))
+  (org-roam-mode +1))
+
+(defun org-roam--test-multi-init ()
+  (let ((original-dir-1 org-roam--tests-directory)
+        (original-dir-2 org-roam--tests-multi)
+        (new-dir-1 (expand-file-name (make-temp-name "org-roam") temporary-file-directory))
+        (new-dir-2 (expand-file-name (make-temp-name "org-roam") temporary-file-directory)))
+    (copy-directory original-dir-1 new-dir-1)
+    (copy-directory original-dir-2 new-dir-2)
+    (setq org-roam-directory new-dir-1)
+    (setq org-roam-directory2 new-dir-2)
     (setq org-roam-mute-cache-build t))
   (org-roam-mode +1))
 
@@ -120,6 +135,148 @@
               (expect (gethash (abs-path "nested/f1.org") (org-roam-titles-cache)) :to-equal "Nested File 1")
               (expect (gethash (abs-path "nested/f2.org") (org-roam-titles-cache)) :to-equal "Nested File 2")
               (expect (gethash (abs-path "no-title.org") (org-roam-titles-cache)) :to-be nil)))
+
+(describe "org-roam--build-cache-async-multi"
+          (it "initializes correctly"
+              (org-roam--clear-cache)
+              (org-roam--test-multi-init)
+              (expect (org-roam-cache-initialized) :to-be nil)
+              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam-titles-cache)) :to-be 0)
+
+              (org-roam--build-cache-async)
+              (sleep-for 3) ;; Because it's async
+
+              ;; Caches should be populated
+              (expect (org-roam-cache-initialized) :to-be t)
+              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
+              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
+              (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
+
+              ;; Forward cache
+              (let ((f1 (gethash (abs-path "f1.org")
+                                 (org-roam-forward-links-cache)))
+                    (f2 (gethash (abs-path "f2.org")
+                                 (org-roam-forward-links-cache)))
+                    (nested-f1 (gethash (abs-path "nested/f1.org")
+                                        (org-roam-forward-links-cache)))
+                    (nested-f2 (gethash (abs-path "nested/f2.org")
+                                        (org-roam-forward-links-cache)))
+                    (expected-f1 (list (abs-path "nested/f1.org")
+                                       (abs-path "f2.org")))
+                    (expected-nested-f1 (list (abs-path "nested/f2.org")
+                                              (abs-path "f1.org")))
+                    (expected-nested-f2 (list (abs-path "nested/f1.org"))))
+
+                (expect f1 :to-have-same-items-as expected-f1)
+                (expect f2 :to-be nil)
+                (expect nested-f1 :to-have-same-items-as expected-nested-f1)
+                (expect nested-f2 :to-have-same-items-as expected-nested-f2))
+
+              ;; Backward cache
+              (let ((f1 (hash-table-keys (gethash (abs-path "f1.org")
+                                                  (org-roam-backward-links-cache))))
+                    (f2 (hash-table-keys (gethash (abs-path "f2.org")
+                                                  (org-roam-backward-links-cache))))
+                    (nested-f1 (hash-table-keys
+                                (gethash (abs-path "nested/f1.org")
+                                         (org-roam-backward-links-cache))))
+                    (nested-f2 (hash-table-keys
+                                (gethash (abs-path "nested/f2.org")
+                                         (org-roam-backward-links-cache))))
+                    (expected-f1 (list (abs-path "nested/f1.org")))
+                    (expected-f2 (list (abs-path "f1.org")))
+                    (expected-nested-f1 (list (abs-path "nested/f2.org")
+                                              (abs-path "f1.org")))
+                    (expected-nested-f2 (list (abs-path "nested/f1.org"))))
+                (expect f1 :to-have-same-items-as expected-f1)
+                (expect f2 :to-have-same-items-as expected-f2)
+                (expect nested-f1 :to-have-same-items-as expected-nested-f1)
+                (expect nested-f2 :to-have-same-items-as expected-nested-f2))
+
+              ;; Titles Cache
+              (expect (gethash (abs-path "f1.org")
+                               (org-roam-titles-cache)) :to-equal "File 1")
+              (expect (gethash (abs-path "f2.org")
+                               (org-roam-titles-cache)) :to-equal "File 2")
+              (expect (gethash (abs-path "nested/f1.org")
+                               (org-roam-titles-cache)) :to-equal "Nested File 1")
+              (expect (gethash (abs-path "nested/f2.org")
+                               (org-roam-titles-cache)) :to-equal "Nested File 2")
+              (expect (gethash (abs-path "no-title.org")
+                               (org-roam-titles-cache)) :to-be nil)
+
+              ;; Multi
+              (let ((org-roam-directory org-roam-directory2))
+                (org-roam--build-cache-async)
+                (sleep-for 3) ;; Because it's async
+
+                ;; Caches should be populated
+                (expect (org-roam-cache-initialized) :to-be t)
+                (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
+                (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
+                (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
+
+                ;; Forward cache
+                (let ((mf1 (gethash (abs-path "mf1.org")
+                                    (org-roam-forward-links-cache)))
+                      (mf2 (gethash (abs-path "mf2.org")
+                                    (org-roam-forward-links-cache)))
+                      (nested-mf1 (gethash (abs-path "nested/mf1.org")
+                                           (org-roam-forward-links-cache)))
+                      (nested-mf2 (gethash (abs-path "nested/mf2.org")
+                                           (org-roam-forward-links-cache)))
+                      (expected-mf1 (list (abs-path "nested/mf1.org")
+                                          (abs-path "mf2.org")))
+                      (expected-nested-mf1 (list (abs-path "nested/mf2.org")
+                                                 (abs-path "mf1.org")))
+                      (expected-nested-mf2 (list (abs-path "nested/mf1.org"))))
+
+                  (expect mf1 :to-have-same-items-as expected-mf1)
+                  (expect mf2 :to-be nil)
+                  (expect nested-mf1 :to-have-same-items-as expected-nested-mf1)
+                  (expect nested-mf2 :to-have-same-items-as expected-nested-mf2))
+
+                ;; Backward cache
+                (let ((mf1 (hash-table-keys
+                            (gethash (abs-path "mf1.org")
+                                     (org-roam-backward-links-cache))))
+                      (mf2 (hash-table-keys
+                            (gethash (abs-path "mf2.org")
+                                     (org-roam-backward-links-cache))))
+                      (nested-mf1 (hash-table-keys
+                                   (gethash (abs-path "nested/mf1.org")
+                                            (org-roam-backward-links-cache))))
+                      (nested-mf2 (hash-table-keys
+                                   (gethash (abs-path "nested/mf2.org")
+                                            (org-roam-backward-links-cache))))
+                      (expected-mf1 (list (abs-path "nested/mf1.org")))
+                      (expected-mf2 (list (abs-path "mf1.org")))
+                      (expected-nested-mf1 (list (abs-path "nested/mf2.org")
+                                                 (abs-path "mf1.org")))
+                      (expected-nested-mf2 (list (abs-path "nested/mf1.org"))))
+                  (expect mf1 :to-have-same-items-as expected-mf1)
+                  (expect mf2 :to-have-same-items-as expected-mf2)
+                  (expect nested-mf1 :to-have-same-items-as expected-nested-mf1)
+                  (expect nested-mf2 :to-have-same-items-as expected-nested-mf2))
+
+                ;; Titles Cache
+                (expect (gethash (abs-path "mf1.org")
+                                 (org-roam-titles-cache))
+                        :to-equal "Multi-File 1")
+                (expect (gethash (abs-path "mf2.org")
+                                 (org-roam-titles-cache))
+                        :to-equal "Multi-File 2")
+                (expect (gethash (abs-path "nested/mf1.org")
+                                 (org-roam-titles-cache))
+                        :to-equal "Nested Multi-File 1")
+                (expect (gethash (abs-path "nested/mf2.org")
+                                 (org-roam-titles-cache))
+                        :to-equal "Nested Multi-File 2")
+                (expect (gethash (abs-path "no-title.org")
+                                 (org-roam-titles-cache))
+                        :to-be nil))))
 
 (describe "org-roam-insert"
           (before-each

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -78,27 +78,27 @@
 (describe "org-roam--build-cache-async"
           (it "initializes correctly"
               (org-roam--test-init)
-              (expect (org-roam-cache-initialized) :to-be nil)
-              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 0)
-              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 0)
-              (expect (hash-table-count (org-roam-titles-cache)) :to-be 0)
+              (expect (org-roam--cache-initialized-p) :to-be nil)
+              (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam--titles-cache)) :to-be 0)
 
               (org-roam--build-cache-async)
               (sleep-for 3) ;; Because it's async
 
               ;; Caches should be populated
-              (expect (org-roam-cache-initialized) :to-be t)
-              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
-              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
-              (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
+              (expect (org-roam--cache-initialized-p) :to-be t)
+              (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 4)
+              (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 5)
+              (expect (hash-table-count (org-roam--titles-cache)) :to-be 5)
 
               ;; Forward cache
-              (let ((f1 (gethash (abs-path "f1.org") (org-roam-forward-links-cache)))
-                    (f2 (gethash (abs-path "f2.org") (org-roam-forward-links-cache)))
+              (let ((f1 (gethash (abs-path "f1.org") (org-roam--forward-links-cache)))
+                    (f2 (gethash (abs-path "f2.org") (org-roam--forward-links-cache)))
                     (nested-f1 (gethash (abs-path "nested/f1.org")
-                                        (org-roam-forward-links-cache)))
+                                        (org-roam--forward-links-cache)))
                     (nested-f2 (gethash (abs-path "nested/f2.org")
-                                        (org-roam-forward-links-cache)))
+                                        (org-roam--forward-links-cache)))
                     (expected-f1 (list (abs-path "nested/f1.org")
                                        (abs-path "f2.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -112,13 +112,13 @@
 
               ;; Backward cache
               (let ((f1 (hash-table-keys (gethash (abs-path "f1.org")
-                                                  (org-roam-backward-links-cache))))
+                                                  (org-roam--backward-links-cache))))
                     (f2 (hash-table-keys (gethash (abs-path "f2.org")
-                                                  (org-roam-backward-links-cache))))
+                                                  (org-roam--backward-links-cache))))
                     (nested-f1 (hash-table-keys(gethash (abs-path "nested/f1.org")
-                                                        (org-roam-backward-links-cache))))
+                                                        (org-roam--backward-links-cache))))
                     (nested-f2 (hash-table-keys (gethash (abs-path "nested/f2.org")
-                                                         (org-roam-backward-links-cache))))
+                                                         (org-roam--backward-links-cache))))
                     (expected-f1 (list (abs-path "nested/f1.org")))
                     (expected-f2 (list (abs-path "f1.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -130,39 +130,39 @@
                 (expect nested-f2 :to-have-same-items-as expected-nested-f2))
 
               ;; Titles Cache
-              (expect (gethash (abs-path "f1.org") (org-roam-titles-cache)) :to-equal "File 1")
-              (expect (gethash (abs-path "f2.org") (org-roam-titles-cache)) :to-equal "File 2")
-              (expect (gethash (abs-path "nested/f1.org") (org-roam-titles-cache)) :to-equal "Nested File 1")
-              (expect (gethash (abs-path "nested/f2.org") (org-roam-titles-cache)) :to-equal "Nested File 2")
-              (expect (gethash (abs-path "no-title.org") (org-roam-titles-cache)) :to-be nil)))
+              (expect (gethash (abs-path "f1.org") (org-roam--titles-cache)) :to-equal "File 1")
+              (expect (gethash (abs-path "f2.org") (org-roam--titles-cache)) :to-equal "File 2")
+              (expect (gethash (abs-path "nested/f1.org") (org-roam--titles-cache)) :to-equal "Nested File 1")
+              (expect (gethash (abs-path "nested/f2.org") (org-roam--titles-cache)) :to-equal "Nested File 2")
+              (expect (gethash (abs-path "no-title.org") (org-roam--titles-cache)) :to-be nil)))
 
 (describe "org-roam--build-cache-async-multi"
           (it "initializes correctly"
               (org-roam--clear-cache)
               (org-roam--test-multi-init)
-              (expect (org-roam-cache-initialized) :to-be nil)
-              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 0)
-              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 0)
-              (expect (hash-table-count (org-roam-titles-cache)) :to-be 0)
+              (expect (org-roam--cache-initialized-p) :to-be nil)
+              (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 0)
+              (expect (hash-table-count (org-roam--titles-cache)) :to-be 0)
 
               (org-roam--build-cache-async)
               (sleep-for 3) ;; Because it's async
 
               ;; Caches should be populated
-              (expect (org-roam-cache-initialized) :to-be t)
-              (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
-              (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
-              (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
+              (expect (org-roam--cache-initialized-p) :to-be t)
+              (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 4)
+              (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 5)
+              (expect (hash-table-count (org-roam--titles-cache)) :to-be 5)
 
               ;; Forward cache
               (let ((f1 (gethash (abs-path "f1.org")
-                                 (org-roam-forward-links-cache)))
+                                 (org-roam--forward-links-cache)))
                     (f2 (gethash (abs-path "f2.org")
-                                 (org-roam-forward-links-cache)))
+                                 (org-roam--forward-links-cache)))
                     (nested-f1 (gethash (abs-path "nested/f1.org")
-                                        (org-roam-forward-links-cache)))
+                                        (org-roam--forward-links-cache)))
                     (nested-f2 (gethash (abs-path "nested/f2.org")
-                                        (org-roam-forward-links-cache)))
+                                        (org-roam--forward-links-cache)))
                     (expected-f1 (list (abs-path "nested/f1.org")
                                        (abs-path "f2.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -176,15 +176,15 @@
 
               ;; Backward cache
               (let ((f1 (hash-table-keys (gethash (abs-path "f1.org")
-                                                  (org-roam-backward-links-cache))))
+                                                  (org-roam--backward-links-cache))))
                     (f2 (hash-table-keys (gethash (abs-path "f2.org")
-                                                  (org-roam-backward-links-cache))))
+                                                  (org-roam--backward-links-cache))))
                     (nested-f1 (hash-table-keys
                                 (gethash (abs-path "nested/f1.org")
-                                         (org-roam-backward-links-cache))))
+                                         (org-roam--backward-links-cache))))
                     (nested-f2 (hash-table-keys
                                 (gethash (abs-path "nested/f2.org")
-                                         (org-roam-backward-links-cache))))
+                                         (org-roam--backward-links-cache))))
                     (expected-f1 (list (abs-path "nested/f1.org")))
                     (expected-f2 (list (abs-path "f1.org")))
                     (expected-nested-f1 (list (abs-path "nested/f2.org")
@@ -197,15 +197,15 @@
 
               ;; Titles Cache
               (expect (gethash (abs-path "f1.org")
-                               (org-roam-titles-cache)) :to-equal "File 1")
+                               (org-roam--titles-cache)) :to-equal "File 1")
               (expect (gethash (abs-path "f2.org")
-                               (org-roam-titles-cache)) :to-equal "File 2")
+                               (org-roam--titles-cache)) :to-equal "File 2")
               (expect (gethash (abs-path "nested/f1.org")
-                               (org-roam-titles-cache)) :to-equal "Nested File 1")
+                               (org-roam--titles-cache)) :to-equal "Nested File 1")
               (expect (gethash (abs-path "nested/f2.org")
-                               (org-roam-titles-cache)) :to-equal "Nested File 2")
+                               (org-roam--titles-cache)) :to-equal "Nested File 2")
               (expect (gethash (abs-path "no-title.org")
-                               (org-roam-titles-cache)) :to-be nil)
+                               (org-roam--titles-cache)) :to-be nil)
 
               ;; Multi
               (let ((org-roam-directory org-roam-directory2))
@@ -213,20 +213,20 @@
                 (sleep-for 3) ;; Because it's async
 
                 ;; Caches should be populated
-                (expect (org-roam-cache-initialized) :to-be t)
-                (expect (hash-table-count (org-roam-forward-links-cache)) :to-be 4)
-                (expect (hash-table-count (org-roam-backward-links-cache)) :to-be 5)
-                (expect (hash-table-count (org-roam-titles-cache)) :to-be 5)
+                (expect (org-roam--cache-initialized-p) :to-be t)
+                (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 4)
+                (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 5)
+                (expect (hash-table-count (org-roam--titles-cache)) :to-be 5)
 
                 ;; Forward cache
                 (let ((mf1 (gethash (abs-path "mf1.org")
-                                    (org-roam-forward-links-cache)))
+                                    (org-roam--forward-links-cache)))
                       (mf2 (gethash (abs-path "mf2.org")
-                                    (org-roam-forward-links-cache)))
+                                    (org-roam--forward-links-cache)))
                       (nested-mf1 (gethash (abs-path "nested/mf1.org")
-                                           (org-roam-forward-links-cache)))
+                                           (org-roam--forward-links-cache)))
                       (nested-mf2 (gethash (abs-path "nested/mf2.org")
-                                           (org-roam-forward-links-cache)))
+                                           (org-roam--forward-links-cache)))
                       (expected-mf1 (list (abs-path "nested/mf1.org")
                                           (abs-path "mf2.org")))
                       (expected-nested-mf1 (list (abs-path "nested/mf2.org")
@@ -241,16 +241,16 @@
                 ;; Backward cache
                 (let ((mf1 (hash-table-keys
                             (gethash (abs-path "mf1.org")
-                                     (org-roam-backward-links-cache))))
+                                     (org-roam--backward-links-cache))))
                       (mf2 (hash-table-keys
                             (gethash (abs-path "mf2.org")
-                                     (org-roam-backward-links-cache))))
+                                     (org-roam--backward-links-cache))))
                       (nested-mf1 (hash-table-keys
                                    (gethash (abs-path "nested/mf1.org")
-                                            (org-roam-backward-links-cache))))
+                                            (org-roam--backward-links-cache))))
                       (nested-mf2 (hash-table-keys
                                    (gethash (abs-path "nested/mf2.org")
-                                            (org-roam-backward-links-cache))))
+                                            (org-roam--backward-links-cache))))
                       (expected-mf1 (list (abs-path "nested/mf1.org")))
                       (expected-mf2 (list (abs-path "mf1.org")))
                       (expected-nested-mf1 (list (abs-path "nested/mf2.org")
@@ -263,19 +263,19 @@
 
                 ;; Titles Cache
                 (expect (gethash (abs-path "mf1.org")
-                                 (org-roam-titles-cache))
+                                 (org-roam--titles-cache))
                         :to-equal "Multi-File 1")
                 (expect (gethash (abs-path "mf2.org")
-                                 (org-roam-titles-cache))
+                                 (org-roam--titles-cache))
                         :to-equal "Multi-File 2")
                 (expect (gethash (abs-path "nested/mf1.org")
-                                 (org-roam-titles-cache))
+                                 (org-roam--titles-cache))
                         :to-equal "Nested Multi-File 1")
                 (expect (gethash (abs-path "nested/mf2.org")
-                                 (org-roam-titles-cache))
+                                 (org-roam--titles-cache))
                         :to-equal "Nested Multi-File 2")
                 (expect (gethash (abs-path "no-title.org")
-                                 (org-roam-titles-cache))
+                                 (org-roam--titles-cache))
                         :to-be nil))))
 
 (describe "org-roam-insert"
@@ -326,16 +326,16 @@
               (rename-file (abs-path "f1.org")
                            (abs-path "new_f1.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (abs-path "f1.org")  (org-roam-forward-links-cache)) :to-be nil)
-              (expect (->> (org-roam-backward-links-cache)
+              (expect (gethash (abs-path "f1.org")  (org-roam--forward-links-cache)) :to-be nil)
+              (expect (->> (org-roam--backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (hash-table-keys)
                            (member (abs-path "f1.org"))) :to-be nil)
 
-              (expect (->> (org-roam-forward-links-cache)
+              (expect (->> (org-roam--forward-links-cache)
                            (gethash (abs-path "new_f1.org"))) :not :to-be nil)
 
-              (expect (->> (org-roam-forward-links-cache)
+              (expect (->> (org-roam--forward-links-cache)
                            (gethash (abs-path "new_f1.org"))
                            (member (abs-path "nested/f1.org"))) :not :to-be nil)
               ;; Links are updated
@@ -348,8 +348,8 @@
               (rename-file (abs-path "f1.org")
                            (abs-path "f1 with spaces.org"))
               ;; Cache should be cleared of old file
-              (expect (gethash (abs-path "f1.org")  (org-roam-forward-links-cache)) :to-be nil)
-              (expect (->> (org-roam-backward-links-cache)
+              (expect (gethash (abs-path "f1.org")  (org-roam--forward-links-cache)) :to-be nil)
+              (expect (->> (org-roam--backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (hash-table-keys)
                            (member (abs-path "f1.org"))) :to-be nil)
@@ -362,15 +362,15 @@
               (rename-file (abs-path "no-title.org")
                            (abs-path "meaningful-title.org"))
               ;; File has no forward links
-              (expect (gethash (abs-path "no-title.org")  (org-roam-forward-links-cache)) :to-be nil)
+              (expect (gethash (abs-path "no-title.org")  (org-roam--forward-links-cache)) :to-be nil)
               (expect (gethash (abs-path "meaningful-title.org")
-                               (org-roam-forward-links-cache)) :to-be nil)
+                               (org-roam--forward-links-cache)) :to-be nil)
 
-              (expect (->> (org-roam-forward-links-cache)
+              (expect (->> (org-roam--forward-links-cache)
                            (gethash (abs-path "f3.org"))
                            (member (abs-path "no-title.org"))) :to-be nil)
 
-              (expect (->> (org-roam-forward-links-cache)
+              (expect (->> (org-roam--forward-links-cache)
                            (gethash (abs-path "f3.org"))
                            (member (abs-path "meaningful-title.org"))) :not :to-be nil)
 
@@ -386,11 +386,11 @@
            (org-roam--test-build-cache))
           (it "delete f1"
               (delete-file (abs-path "f1.org"))
-              (expect (->> (org-roam-forward-links-cache)
+              (expect (->> (org-roam--forward-links-cache)
                            (gethash (abs-path "f1.org"))) :to-be nil)
-              (expect (->> (org-roam-backward-links-cache)
+              (expect (->> (org-roam--backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (gethash (abs-path "f1.org"))) :to-be nil)
-              (expect (->> (org-roam-backward-links-cache)
+              (expect (->> (org-roam--backward-links-cache)
                            (gethash (abs-path "nested/f1.org"))
                            (gethash (abs-path "nested/f2.org"))) :not :to-be nil)))


### PR DESCRIPTION
ref #80 

###### Motivation for this change
I have multiple contexts that I use org-roam in. I would like to use org-roam concurrently with my various repositories of org files. At the same time, I want to keep them separate, as work files shouldn't link to my personal files and vice-versa.

###### Summary of changes
This commit gives each org-roam-directory its own cache.  This was anyone that wants to have multiple org-roam directories can do so by configuring a `.dir-locals.el` for the extra repository.

Example .dir-locals.el file:
```lisp
((org-mode . ((eval . (setq-local org-roam-directory (expand-file-name "./"))))))
```