### PR TITLE
(feature): support file aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.3 (TBD)
 
+### New Features
+* [#182][gh-182] Support file name aliases via `#+ROAM_ALIAS`.
+
 ### Features
 * [#165][gh-165] Add templating functionality via `org-roam-templates`.
 
@@ -93,6 +96,7 @@ Mostly a documentation/cleanup release.
 [gh-142]: https://github.com/jethrokuan/org-roam/pull/142
 [gh-143]: https://github.com/jethrokuan/org-roam/pull/143
 [gh-165]: https://github.com/jethrokuan/org-roam/pull/165
+[gh-182]: https://github.com/jethrokuan/org-roam/pull/182
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -35,6 +35,7 @@
 
 (require 'org)
 (require 'org-element)
+(require 'ob-core) ;for org-babel-parse-header-arguments
 (require 'subr-x)
 (require 'cl-lib)
 
@@ -127,15 +128,56 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
           (puthash p-from (list props) contents-hash)
           (puthash p-to contents-hash backward))))))
 
-(defun org-roam--extract-title ()
-  "Extract the title from `BUFFER'."
-  (org-element-map
-      (org-element-parse-buffer)
-      'keyword
-    (lambda (kw)
-      (when (string= (org-element-property :key kw) "TITLE")
-        (org-element-property :value kw)))
-    :first-match t))
+(defun org-roam--extract-global-props (props)
+  "Extract PROPS from the current buffer."
+  (let ((buf (org-element-parse-buffer))
+        (res '()))
+    (dolist (prop props)
+      (let ((p (org-element-map
+                   buf
+                   'keyword
+                 (lambda (kw)
+                   (when (string= (org-element-property :key kw) prop)
+                     (org-element-property :value kw)))
+                 :first-match t)))
+        (setq res (cons (cons prop p) res))))
+    res))
+
+(defun org-roam--aliases-str-to-list (str)
+  "Function to transform string STR into list of alias titles.
+
+This snippet is obtained from ox-hugo:
+https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff7282e3c/ox-hugo.el#L3131"
+  (when (stringp str)
+    (let* ((str (org-trim str))
+           (str-list (split-string str "\n"))
+           ret)
+      (dolist (str-elem str-list)
+        (let* ((format-str ":dummy '(%s)") ;The :dummy key is discarded in the `lst' var below.
+               (alist (org-babel-parse-header-arguments (format format-str str-elem)))
+               (lst (cdr (car alist)))
+               (str-list2 (mapcar (lambda (elem)
+                                    (cond
+                                     ((symbolp elem)
+                                      (symbol-name elem))
+                                     (t
+                                      elem)))
+                                  lst)))
+          (setq ret (append ret str-list2))))
+      ret)))
+
+(defun org-roam--extract-titles ()
+  "Extract the titles from current buffer.
+
+Titles are obtained via the #+TITLE property, or aliases
+specified via the #+ROAM_ALIAS property."
+  (let* ((props (org-roam--extract-global-props '("TITLE" "ROAM_ALIAS")))
+         (aliases (cdr (assoc "ROAM_ALIAS" props)))
+         (title (cdr (assoc "TITLE" props)))
+         (alias-list (org-roam--aliases-str-to-list aliases)))
+    (if title
+        (cons title alias-list)
+      alias-list)))
 
 (defun org-roam--build-cache (dir)
   "Build the org-roam caches in DIR."
@@ -156,8 +198,8 @@ ITEM is of the form: (:from from-path :to to-path :properties (:content preview-
       (dolist (file org-roam-files)
         (with-temp-buffer
           (insert-file-contents file)
-          (when-let ((title (org-roam--extract-title)))
-            (puthash file title file-titles)))
+          (when-let ((titles (org-roam--extract-titles)))
+            (puthash file titles file-titles)))
         org-roam-files))
     (list
      :directory dir

--- a/tests/roam-files/alias.org
+++ b/tests/roam-files/alias.org
@@ -1,0 +1,2 @@
+#+ROAM_ALIAS: "a1" "a 2"
+#+TITLE: t1


### PR DESCRIPTION
This adds support for title aliases, for a particular note via the `#+ROAM_ALIAS` key, e.g.:

```
#+ROAM_ALIAS: "alias 1" "alias 2" three four five
```

These aliases are valid in `org-roam-find-file` and `org-roam-insert`.

###### Motivation for this change

Addresses #91.