### PR TITLE
(performance): avoid path expansion by referencing cache obj

### DIFF
--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -68,11 +68,11 @@
 (defun org-roam--test-build-cache ()
   "Builds the caches synchronously."
   (let ((cache (org-roam--build-cache org-roam-directory)))
-    (org-roam--set-directory-cache
-     (org-roam-cache :initialized t
-                     :forward-links (plist-get cache :forward)
-                     :backward-links (plist-get cache :backward)
-                     :titles (plist-get cache :titles)))))
+    (let ((obj (org-roam--get-directory-cache)))
+      (oset obj initialized t)
+      (oset obj forward-links (plist-get cache :forward))
+      (oset obj backward-links (plist-get cache :backward))
+      (oset obj titles (plist-get cache :titles)))))
 
 ;;; Tests
 (describe "org-roam--build-cache-async"


### PR DESCRIPTION
Prevent needless repeated calls to org-roam-directory-normalized by having a reference to the cache object that matches the local buffer.

###### Motivation for this change
May be better to avoid repeated calls of `file-truename` and `directory-file-name` and `equal` when the local buffer can keep a reference to its local repository cache object.