### PR TITLE
(docs): Add documentation for #+ROAM_ALIAS property

### DIFF
--- a/doc/anatomy.md
+++ b/doc/anatomy.md
@@ -1,0 +1,16 @@
+The bulk of Org-roam's functionality is built on top of vanilla
+Org-mode features. However, to support additional functionality,
+Org-roam adds several Org-roam-specific keywords. This functionality
+is not crucial to effective use of Org-roam.
+
+## File Aliases
+
+Suppose you want a note to be referred to by different names (e.g.
+"World War 2", "WWII"). You may specify such aliases using the file
+`#+ROAM_ALIAS` attribute:
+
+```org
+#+TITLE: World War 2
+#+ROAM_ALIAS: "WWII" "World War II"
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
 - A Tour of Org-Roam: tour.md
 - Installation: installation.md
 - Configuration: configuration.md
+- Anatomy of a Roam file: anatomy.md
 - Ecosystem: ecosystem.md
 - Similar Packages: comparison.md
 - "Appendix: Note-taking Workflow": notetaking_workflow.md


### PR DESCRIPTION
###### Motivation for this change

Documents the new Org-roam specific `#+ROAM_ALIAS` property.