### PR TITLE
(docs): remove `:after` from package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The recommended method is using use-package and straight, or a similar package m
 
 ```emacs-lisp
 (use-package org-roam
-      :after org
       :hook 
       (after-init . org-roam-mode)
       :straight (:host github :repo "jethrokuan/org-roam" :branch "develop")

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,7 +5,6 @@ The recommended method is using [use-package][use-package] and
 
 ```
 (use-package org-roam
-      :after org
       :hook 
       (after-init . org-roam-mode)
       :straight (:host github :repo "jethrokuan/org-roam" :branch "develop")
@@ -28,7 +27,6 @@ git clone https://github.com/jethrokuan/org-roam/ ~/.emacs.d/elisp/org-roam
 
 ```
 (use-package org-roam
-      :after org
       :load-path "elisp/"
       :hook 
       (after-init . org-roam-mode)
@@ -66,7 +64,6 @@ If you are using Spacemacs, you can easily install org-roam by creating a simple
 
 (defun org-roam/init-org-roam ()
     (use-package org-roam
-        :after org
         :hook
         (after-init . org-roam-mode)
         :custom


### PR DESCRIPTION
Some of org-roam's functions (e.g. org-roam-today and org-roam-find-file) should not need to have org loaded before use.

I'm not sure if this will fix it, since the `:hook` specification should cause the package to load. In any case, the Spacemacs installation instructions should be updated to bind the keys to the `org-roam-mode` minor mode, instead of the global org-mode.

###### Motivation for this change

#133 and #181 show people having issues with installation.