### PR TITLE
(feature): add a cache for roam keys

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -183,7 +183,8 @@ specified via the #+ROAM_ALIAS property."
   "Build the org-roam caches in DIR."
   (let ((backward-links (make-hash-table :test #'equal))
         (forward-links (make-hash-table :test #'equal))
-        (file-titles (make-hash-table :test #'equal)))
+        (file-titles (make-hash-table :test #'equal))
+        (refs (make-hash-table :test #'equal)))
     (let* ((org-roam-files (org-roam--find-files dir))
            (file-items (mapcar (lambda (file)
                                  (with-temp-buffer
@@ -199,13 +200,18 @@ specified via the #+ROAM_ALIAS property."
         (with-temp-buffer
           (insert-file-contents file)
           (when-let ((titles (org-roam--extract-titles)))
-            (puthash file titles file-titles)))
+            (puthash file titles file-titles))
+          (when-let ((ref (cdr (assoc "ROAM_KEY" (org-roam--extract-global-props '("ROAM_KEY"))))))
+            ;; FIXME: this overrides previous refs, should probably have a
+            ;; warning when ref is not unique
+            (puthash ref file refs)))
         org-roam-files))
     (list
      :directory dir
      :forward forward-links
      :backward backward-links
-     :titles file-titles)))
+     :titles file-titles
+     :refs refs)))
 
 (provide 'org-roam-utils)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -170,7 +170,9 @@ If called interactively, then PARENTS is non-nil."
    (backward-links :initarg :backward-links
                    :documentation "Cache containing backward links.")
    (titles :initarg :titles
-           :documentation "Cache containing titles for org-roam files."))
+           :documentation "Cache containing titles for org-roam files.")
+   (refs :initarg :refs
+         :documentation "Cache with ref as key, and file path as value."))
   "All cache for an org-roam directory.")
 
 ;;; Dynamic variables
@@ -235,6 +237,10 @@ as a unique key."
 (defun org-roam--titles-cache ()
   "Cache containing titles for org-roam files."
   (oref (org-roam--get-directory-cache) titles))
+
+(defun org-roam--refs-cache ()
+  "Cache containing refs for org-roam files."
+  (oref (org-roam--get-directory-cache) refs))
 
 (defun org-roam--ensure-cache-built ()
   "Ensures that org-roam cache is built."
@@ -459,7 +465,8 @@ If PREFIX, downcase the title before insertion."
               (oset obj initialized t)
               (oset obj forward-links (plist-get cache :forward))
               (oset obj backward-links (plist-get cache :backward))
-              (oset obj titles (plist-get cache :titles)))
+              (oset obj titles (plist-get cache :titles))
+              (oset obj refs (plist-get cache :refs)))
             (unless org-roam-mute-cache-build
               (message "Org-roam cache built!"))
             (when on-success
@@ -472,18 +479,19 @@ If PREFIX, downcase the title before insertion."
     (oset cache initialized nil)
     (oset cache forward-links (make-hash-table :test #'equal))
     (oset cache backward-links (make-hash-table :test #'equal))
-    (oset cache titles (make-hash-table :test #'equal))))
+    (oset cache titles (make-hash-table :test #'equal))
+    (oset cache refs (make-hash-table :test #'equal))))
 
 (defun org-roam--default-cache ()
   "A default, uninitialized cache object."
   (org-roam-cache :initialized nil
                   :forward-links (make-hash-table :test #'equal)
                   :backward-links (make-hash-table :test #'equal)
-                  :titles (make-hash-table :test #'equal)))
+                  :titles (make-hash-table :test #'equal)
+                  :refs (make-hash-table :test #'equal)))
 
 (defun org-roam--clear-file-from-cache (&optional filepath)
-  "Remove any related links to the file.
-
+  "Remove any related links to the file at FILEPATH.
 This is equivalent to removing the node from the graph."
   (let* ((path (or filepath
                    (buffer-file-name (current-buffer))))

--- a/tests/roam-files/web_ref.org
+++ b/tests/roam-files/web_ref.org
@@ -1,0 +1,1 @@
+#+ROAM_KEY: https://google.com/

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -72,7 +72,8 @@
       (oset obj initialized t)
       (oset obj forward-links (plist-get cache :forward))
       (oset obj backward-links (plist-get cache :backward))
-      (oset obj titles (plist-get cache :titles)))))
+      (oset obj titles (plist-get cache :titles))
+      (oset obj refs (plist-get cache :refs)))))
 
 ;;; Tests
 (describe "org-roam--build-cache-async"
@@ -92,6 +93,7 @@
               (expect (hash-table-count (org-roam--forward-links-cache)) :to-be 4)
               (expect (hash-table-count (org-roam--backward-links-cache)) :to-be 5)
               (expect (hash-table-count (org-roam--titles-cache)) :to-be 6)
+              (expect (hash-table-count (org-roam--refs-cache)) :to-be 1)
 
               ;; Forward cache
               (let ((f1 (gethash (abs-path "f1.org")
@@ -147,6 +149,10 @@
                                (org-roam--titles-cache)) :to-equal (list "t1" "a1" "a 2"))
               (expect (gethash (abs-path "no-title.org")
                                (org-roam--titles-cache)) :to-be nil)
+
+              ;; Refs Cache
+              (expect (gethash "https://google.com/"
+                               (org-roam--refs-cache)) :to-equal (abs-path "web_ref.org"))
 
               ;; Multi
               (let ((org-roam-directory org-roam-directory2))


### PR DESCRIPTION
This adds a cache for roam keys.

Each file has 1 roam key (string), specified by the the global `#+ROAM_KEY` attribute.

The key should point to a unique source of information: e.g.

1. `#+ROAM_KEY: https://google.com` notes for a website
2. `#+ROAM_KEY: cite:bibkey` notes for a bibliographic key
 
###### Motivation for this change

These keys will be used in future applications: e.g. having a firefox bookmark open up notes for a particular website.