### PR TITLE
(feature): deprecate roam-protocol, extend org-protocol instead

### DIFF
--- a/doc/roam_protocol.md
+++ b/doc/roam_protocol.md
@@ -1,5 +1,33 @@
-The setup is the same as org-protocol. Here `roam://` links are
-defined, and need to be associated with an application. 
+## What is Roam protocol?
+
+Org-roam defines several protocols that help boost productivity, by
+extending `org-protocol`. 
+
+In the generated graph, to force file links to open in Emacs, we use
+`org-protocol`.
+
+In addition, we can also use a Firefox bookmarklet to associate
+notes with any unique key. 
+
+<blockquote class="imgur-embed-pub" lang="en" data-id="a/sKuEske"><a
+href="//imgur.com/a/sKuEske"></a></blockquote><script async
+src="//s.imgur.com/min/embed.js" charset="utf-8"></script>
+
+Add the following snippet as a bookmarklet:
+
+```javascript
+javascript:location.href =
+'org-protocol://roam-ref?template=ref&ref='
++ encodeURIComponent(location.href)
++ '&title='
++ encodeURIComponent(document.title)
+```
+
+where `template` is the template you have defined for your web
+snippets. This template should contain a `#+ROAM_KEY: {ref}` in it.
+
+## Org-protocol Setup
+The setup is the exact same as org-protocol. 
 
 Across all platforms, to enable `org-roam-protocol`, you have to add
 the following to your init file:
@@ -14,27 +42,27 @@ instructions for various platforms are shown below:
 ## Linux
 
 Create a desktop application. I place mine in
-`~/.local/share/applications/roam.desktop`:
+`~/.local/share/applications/org-protocol.desktop`:
 
 ```
 [Desktop Entry]
-Name=Org-Roam Client
+Name=Org-Protocol
 Exec=emacsclient %u
 Icon=emacs-icon
 Type=Application
 Terminal=false
-MimeType=x-scheme-handler/roam
+MimeType=x-scheme-handler/org-protocol
 ```
 
-Associate `roam://` links with the desktop application by
+Associate `org-protocol://` links with the desktop application by
 running in your shell:
 
 ```bash
-xdg-mime default roam.desktop x-scheme-handler/roam
+xdg-mime default org-protocol.desktop x-scheme-handler/org-protocol
 ```
 
 To disable the "confirm" prompt in Chrome, you can also make Chrome
-show a checkbox to tick, so that the `Org-Roam Client` app will be used
+show a checkbox to tick, so that the `Org-Protocol Client` app will be used
 without confirmation. To do this, run in a shell:
 
 ```sh
@@ -72,17 +100,17 @@ brew cask install playtpus
 
 2. Platypus settings:
 
-- App Name: `OrgRoam`
+- App Name: `OrgProtocol`
 - Script Type: `env` and `/usr/bin/env`
 - Script Path: `/path/to/emacsclient $1`
 - Tick Accept dropped items and click Settings
 - Tick Accept dropped files
 - Tick Register as URI scheme handler
-- Add `roam` as a protocol
+- Add `org-protocol` as a protocol
 - Create the app
 
 To disable the "confirm" prompt in Chrome, you can also make Chrome
-show a checkbox to tick, so that the `OrgRoam` app will be used
+show a checkbox to tick, so that the `OrgProtocol` app will be used
 without confirmation. To do this, run in a shell:
 
 ```sh

--- a/doc/roam_protocol.md
+++ b/doc/roam_protocol.md
@@ -1,23 +1,22 @@
 ## What is Roam protocol?
 
-Org-roam defines several protocols that help boost productivity, by
+Org-roam defines two protocols that help boost productivity, by
 extending `org-protocol`. 
 
-In the generated graph, to force file links to open in Emacs, we use
-`org-protocol`.
+The first protocol is the `roam-file` protocol. This is a simple
+protocol that opens the path specified by the `file` key (e.g.
+`org-protocol:/roam-file?file=/tmp/file.org`). This is used in the
+generated graph.
 
-In addition, we can also use a Firefox bookmarklet to associate
-notes with any unique key. 
+The second protocol is the `roam-ref` protocol. This protocol finds or
+creates a new note with a given `ROAM_KEY` (see
+[Anatomy](anatomy.md)).
 
-<blockquote class="imgur-embed-pub" lang="en" data-id="a/sKuEske"><a
-href="//imgur.com/a/sKuEske"></a></blockquote><script async
-src="//s.imgur.com/min/embed.js" charset="utf-8"></script>
-
-Add the following snippet as a bookmarklet:
+To use this, create a Firefox bookmarklet as follows:
 
 ```javascript
 javascript:location.href =
-'org-protocol://roam-ref?template=ref&ref='
+'org-protocol:/roam-ref?template=ref&ref='
 + encodeURIComponent(location.href)
 + '&title='
 + encodeURIComponent(document.title)
@@ -27,7 +26,9 @@ where `template` is the template you have defined for your web
 snippets. This template should contain a `#+ROAM_KEY: {ref}` in it.
 
 ## Org-protocol Setup
-The setup is the exact same as org-protocol. 
+
+The instructions for setting up org-protocol can be found
+[here][org-protocol-inst], but they are reproduced below.
 
 Across all platforms, to enable `org-roam-protocol`, you have to add
 the following to your init file:
@@ -116,3 +117,5 @@ without confirmation. To do this, run in a shell:
 ```sh
 defaults write com.google.Chrome ExternalProtocolDialogShowAlwaysOpenCheckbox -bool true
 ```
+
+[org-protocol-inst]: https://orgmode.org/worg/org-contrib/org-protocol.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
 - Ecosystem: ecosystem.md
 - Similar Packages: comparison.md
 - "Appendix: Note-taking Workflow": notetaking_workflow.md
-- "Appendix: Graph Setup": graph_setup.md
+- "Appendix: Roam Protocol": roam_protocol.md
 markdown_extensions:
   - admonition
   - pymdownx.betterem:

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -53,9 +53,21 @@ This function detects an file, and opens it.
       (org-roam-find-ref decoded-alist)))
   nil)
 
-(setq org-protocol-protocol-alist
-      (cons '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)
-            org-protocol-protocol-alist))
+(defun org-roam-protocol-open-file (info)
+  "Process an org-protocol://roam-ref?ref= style url with INFO.
+
+  Example protocol string:
+
+org-protocol://roam-file?file=/path/to/file.org"
+  (when-let ((file (plist-get info :file)))
+    (raise-frame)
+    (find-file file))
+  nil)
+
+(push '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)
+      org-protocol-protocol-alist)
+(push '("org-roam-file"  :protocol "roam-file"   :function org-roam-protocol-open-file)
+      org-protocol-protocol-alist)
 
 (provide 'org-roam-protocol)
 

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -1,4 +1,4 @@
-;;; org-roam-protocol.el --- Protocol handler for roam:// links
+;;; org-roam-protocol.el --- Protocol handler for roam:// links  -*- coding: utf-8; lexical-binding: t -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 ;; Author: Jethro Kuan <jethrokuan95@gmail.com>
@@ -22,67 +22,40 @@
 
 ;;; Commentary:
 ;;
-;; Intercept calls from emacsclient for `roam://' links.
+;; We extend org-protocol, adding custom Org-roam handlers. The setup
+;; instructions for `org-protocol' can be found in org-protocol.el.
 ;;
-;; This is done by advising `server-visit-files' to scan the list of filenames
-;; for `org-roam-protocol-the-protocol'.
-;;
-;; `roam://' links are expected to be absolute file locations, for example,
-;; `roam:///home/me/file.org'. The `roam://' prefix is stripped, and emacsclient
-;; opens the location as per usual.
-;;
-;; Any application that supports calling external programs with an URL as
-;; argument may be used with this functionality.
-;;
-;; Usage:
-;; ------
-;;
-;;    1.) Add this to your init file:
-;;        (add-to-list 'load-path "/path/to/org-roam-protocol.el"')
-;;        (require 'org-roam-protocol)
-;;
-;;    2.) Ensure emacs-server is up and running.
-;;    3.) Try this from the command line:
-;;        $ emacsclient roam:///tmp/test.org
-;;
-;;    If it works, you can now setup other applications for using this feature.
-
-(require 'org)
-
-;;; Variables:
-
-(defconst org-roam-protocol-the-protocol "roam"
-  "This is the protocol to detect if org-roam-protocol.el is loaded.
-You will have to define just one protocl handler OS-wide (MS-Windows)
-or per application (Linux). That protocol handler should call emacsclient.")
-
 ;;; Code:
-(defun org-roam-protocol-check-filename-for-protocol (fname)
-  "Check if `org-roam-protocol-the-protocol' is used in FNAME.
 
-If the protocol is found, the protocol is stripped from fname,
-and the value is passed to the server as filename.
+(require 'org-protocol)
+(require 'org-roam-utils)
 
-If the function returns nil, the filename is removed from the
-list of filenames passed from emacsclient to the server. If the
-function returns a non-nil value, that value is passed to the
-server as filename."
-  (let ((the-protocol (concat (regexp-quote org-roam-protocol-the-protocol) ":")))
-    (when (string-match the-protocol fname)
-      (cadr (split-string fname the-protocol)))))
+(defun org-roam-protocol-open-ref (info)
+  "Process an org-protocol://roam-ref?ref= style url with INFO.
 
-(defadvice server-visit-files (before org-roam-protocol-detect-protocol-server activate)
-  "Advice `server-visit-files' to strip the `roam:/' protocol.
-Default to `server-find-files' handling for file locations."
-  (let ((flist (ad-get-arg 0)))
-    (dolist (var flist)
-      ;; `\' to '/' on windows.
-      (let ((fname (expand-file-name (car var)))
-            org-roam-location)
-        (setq org-roam-location (org-roam-protocol-check-filename-for-protocol
-                                 fname))
-        (when (stringp org-roam-location) ; location for Org-roam file
-          (setcar var org-roam-location))))))
+The sub-protocol used to reach this function is set in
+`org-protocol-protocol-alist'.
+
+This function decodes a ref, and places it into
+This function detects an file, and opens it.
+
+  javascript:location.href = \\='org-protocol://roam-ref?ref=\\='+ \\
+        encodeURIComponent(location.href) + \\='&title=\\=' \\
+        encodeURIComponent(document.title) + \\='&body=\\=' + \\
+        encodeURIComponent(window.getSelection())"
+  (when-let* ((alist (org-roam--plist-to-alist info))
+              (decoded-alist (mapcar (lambda (k.v)
+                                       (let ((key (car k.v))
+                                             (val (cdr k.v)))
+                                         (cons key (org-link-decode val)))) alist)))
+    (when (assoc 'ref decoded-alist)
+      (raise-frame)
+      (org-roam-find-ref decoded-alist)))
+  nil)
+
+(setq org-protocol-protocol-alist
+      (cons '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)
+            org-protocol-protocol-alist))
 
 (provide 'org-roam-protocol)
 

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'f)
+(require 'ob-core)  ;for org-babel-parse-header-arguments
 
 (defun org-roam--plist-to-alist (plist)
   "Return an alist of the property-value pairs in PLIST."
@@ -41,6 +42,56 @@
   "Touches an empty file at PATH."
   (make-directory (file-name-directory path) t)
   (f-touch path))
+
+(defun org-roam--file-name-extension (filename)
+  "Return file name extension for FILENAME.
+Like file-name-extension, but does not strip version number."
+  (save-match-data
+    (let ((file (file-name-nondirectory filename)))
+      (if (and (string-match "\\.[^.]*\\'" file)
+               (not (eq 0 (match-beginning 0))))
+          (substring file (+ (match-beginning 0) 1))))))
+
+(defun org-roam--org-file-p (path)
+  "Check if PATH is pointing to an org file."
+  (let ((ext (org-roam--file-name-extension path)))
+    (or (string= ext "org")
+        (and
+         (string= ext "gpg")
+         (string= (org-roam--file-name-extension (file-name-sans-extension path)) "org")))))
+
+(defun org-roam--org-roam-file-p (&optional file)
+  "Return t if FILE is part of org-roam system, return nil otherwise.
+If FILE is not specified, use the current-buffer file path."
+  (let ((path (or file
+                  (buffer-file-name (current-buffer)))))
+    (and path
+         (org-roam--org-file-p path)
+         (f-descendant-of-p (file-truename path)
+                            (file-truename org-roam-directory)))))
+
+(defun org-roam--aliases-str-to-list (str)
+  "Function to transform string STR into list of alias titles.
+
+This snippet is obtained from ox-hugo:
+https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff7282e3c/ox-hugo.el#L3131"
+  (when (stringp str)
+    (let* ((str (org-trim str))
+           (str-list (split-string str "\n"))
+           ret)
+      (dolist (str-elem str-list)
+        (let* ((format-str ":dummy '(%s)") ;The :dummy key is discarded in the `lst' var below.
+               (alist (org-babel-parse-header-arguments (format format-str str-elem)))
+               (lst (cdr (car alist)))
+               (str-list2 (mapcar (lambda (elem)
+                                    (cond
+                                     ((symbolp elem)
+                                      (symbol-name elem))
+                                     (t
+                                      elem)))
+                                  lst)))
+          (setq ret (append ret str-list2))))
+      ret)))
 
 ;;; -
 (provide 'org-roam-utils)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -1,0 +1,47 @@
+;;; org-roam-utils.el --- Org-roam utility functions  -*- coding: utf-8; lexical-binding: t -*-
+
+;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
+;; Author: Jethro Kuan <jethrokuan95@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; Provides several utility functions used throughout Org-roam.
+;;
+;;; Code:
+
+(require 'f)
+
+(defun org-roam--plist-to-alist (plist)
+  "Return an alist of the property-value pairs in PLIST."
+  (let (res)
+    (while plist
+      (let ((prop (intern (substring (symbol-name (pop plist)) 1 nil)))
+            (val (pop plist)))
+        (push (cons prop val) res)))
+    res))
+
+(defun org-roam--touch-file (path)
+  "Touches an empty file at PATH."
+  (make-directory (file-name-directory path) t)
+  (f-touch path))
+
+;;; -
+(provide 'org-roam-utils)
+;;; org-roam-utils.el ends here


### PR DESCRIPTION
Rather than having our own protocol, we use org-protocol's underlying functionality and extend org-protocol instead.

We add 2 custom handlers:

1. `roam-file?file=path`: this simply opens the file at `path` in Emacs.
2. `roam-ref?ref=ref&template=roam-template&title=title&...`: attempts to open a roam note with a given `ROAM_KEY`. If the note doesn't exist, create one. Else, open it.

If you're curious, I uploaded a video of it on Twitter:
https://twitter.com/jethroksy/status/1233408971437821952?s=09

###### Motivation for this change
See #189 