### PR TITLE
(bugfix): Only match protocol at beginning of URL

### DIFF
--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -67,7 +67,7 @@ If the function returns nil, the filename is removed from the
 list of filenames passed from emacsclient to the server. If the
 function returns a non-nil value, that value is passed to the
 server as filename."
-  (let ((the-protocol (concat (regexp-quote org-roam-protocol-the-protocol) ":")))
+  (let ((the-protocol (concat "^" (regexp-quote org-roam-protocol-the-protocol) ":")))
     (when (string-match the-protocol fname)
       (cadr (split-string fname the-protocol)))))
 


### PR DESCRIPTION
Prevents handling of non-roam links like org-roam:pros.txt

###### Motivation for this change
Executing

```
emacsclient org-roam:pros.txt
```
results in a text file `pros.txt` instead of `org-roam:pros.txt`
