### PR TITLE
(fix): build org-roam cache on org-roam-mode

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -851,6 +851,7 @@ If ARG is `toggle', toggle `org-roam-mode'. Otherwise, behave as if called inter
   :global t
   (cond
    (org-roam-mode
+    (org-roam-build-cache)
     (add-hook 'find-file-hook #'org-roam--find-file-hook-function)
     (add-hook 'kill-emacs-hook #'org-roam--db-close-all)
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)


### PR DESCRIPTION
`org-roam-build-cache` takes very little time, when the cache is already built running it on `org-roam-mode` ensures that the cache is consistent with the files.