### PR TITLE
(bugfix): fix delete-file advice triggering on non-org-roam files

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -791,7 +791,9 @@ This sets `file:' Org links to have the org-link face."
 
 (defun org-roam--delete-file-advice (file &optional _trash)
   "Advice for maintaining cache consistency during file deletes."
-  (org-roam--db-clear-file (file-truename file)))
+  (when (and (not (auto-save-file-name-p file))
+             (org-roam--org-roam-file-p file))
+    (org-roam--db-clear-file (file-truename file))))
 
 (defun org-roam--rename-file-advice (file new-file &rest args)
   "Rename backlinks of FILE to refer to NEW-FILE."


### PR DESCRIPTION
Adding a predicate for the delete-file advice ensures that expensive SQL operations do not run when not necessary.