### PR TITLE
(bugfix): use "org-roam" as graphname

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -975,7 +975,7 @@ The file-links table is then read to obtain all directed links, and formatted
 into a digraph."
   (org-roam--db-ensure-built)
   (with-temp-buffer
-	  (insert "digraph {\n")
+	  (insert "digraph \"org-roam\" {\n")
     (let ((rows (org-roam-sql [:select [file titles] :from titles])))
       (dolist (row rows)
         (let* ((file (xml-escape-string (car row)))


### PR DESCRIPTION
###### Motivation for this change
The graphname is displayed as tooltip when hovering over non-node
areas in the SVG viewer.

When grahname is undefined Chrome and Firefox just displays
"%3" (ETX/End of Text).

![roam](https://user-images.githubusercontent.com/52547/75779306-b0542b00-5d59-11ea-8b40-2cf4ab3f701b.png)

