### PR TITLE
(docs): add documentation for exporting backlinks in Org file

### DIFF
--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -1,0 +1,23 @@
+To include the backlinks in your Org file export -- whether using Org's
+in-built publishing or ox-hugo -- use the following snippet to add a
+"Backlinks" section at the end of the page:
+
+```emacs-lisp
+(defun my/org-roam--backlinks-list (file)
+  (if (org-roam--org-roam-file-p file)
+      (--reduce-from
+       (concat acc (format "- [[file:%s][%s]]\n"
+                           (file-relative-name (car it) org-roam-directory)
+			                     (org-roam--get-title-or-slug (car it))))
+       "" (org-roam-sql [:select [file-from] :from file-links :where (= file-to $s1)] file))
+    ""))
+
+(defun my/org-export-preprocessor (backend)
+  (let ((links (my/org-roam--backlinks-list (buffer-file-name))))
+    (unless (string= links "")
+      (save-excursion
+      	(goto-char (point-max))
+      	(insert (concat "\n* Backlinks\n") links)))))
+
+(add-hook 'org-export-before-processing-hook 'my/org-export-preprocessor)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
 - Similar Packages: comparison.md
 - "Appendix: Note-taking Workflow": notetaking_workflow.md
 - "Appendix: Roam Protocol": roam_protocol.md
+- "Appendix: Org Export": org_export.md
 markdown_extensions:
   - admonition
   - pymdownx.betterem:


### PR DESCRIPTION
###### Motivation for this change
Addresses #220 

Adding a basic version of @jdiez17's preprocessing advice to the appendix in the docs.