### PR TITLE
(feature): introduce org-roam-backlink face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ templating system using `org-capture` is introduced.
 * [#216][gh-216] Adds templating functionality by extending org-capture.
 * [#232][gh-232] Adds a prefix key to `org-roam-show-graph`, to generate graph without opening it.
 * [#233][gh-233] Adds `org-roam-graph-exclude-matcher`, which allows exclusion of nodes from graph.
+* [#247][gh-247] Add `org-roam-backlink` face, which allows customizing backlinks appearance
 
 ### Bugfixes
 * [#207][gh-207], [#221][gh-221] small bugfixes to Org-roam graph generation
@@ -119,6 +120,7 @@ Mostly a documentation/cleanup release.
 [gh-216]: https://github.com/jethrokuan/org-roam/pull/216
 [gh-221]: https://github.com/jethrokuan/org-roam/pull/221
 [gh-230]: https://github.com/jethrokuan/org-roam/pull/230
+[gh-247]: https://github.com/jethrokuan/org-roam/pull/247
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -53,6 +53,9 @@ frame width. For example:
 
 Will result in the Org-roam buffer taking up 40% of the screen width.
 
+You can change backlinks appearance in the buffer by customizing
+`org-roam-backlink` face (`M-x customize-face org-roam-backlink`).
+
 ## Org-roam Links
 
 By default, links are inserted with the title as the link description.
@@ -65,7 +68,7 @@ choose add special indicators for Org-roam links by tweaking
 ```
 
 If your version of Org is at least `9.2`, you may also choose to
-simply style the link differently, by customizing `org-roam-link-face`
+simply style the link differently, by customizing `org-roam-link` face
 (`M-x customize-face org-roam-link`).
 
 ## Org-roam Files

--- a/org-roam.el
+++ b/org-roam.el
@@ -890,6 +890,11 @@ INFO is an alist containing additional information."
   "Face for org-roam link."
   :group 'org-roam-faces)
 
+(defface org-roam-backlink
+  '((t :inherit org-block))
+  "Face for org-roam backlinks in backlinks buffer"
+  :group 'org-roam-faces)
+
 (defun org-roam--roam-link-face (path)
   "Conditional face for org file links.
 Applies `org-roam-link-face' if PATH correponds to a Roam file."
@@ -1002,7 +1007,7 @@ If item at point is not org-roam specific, default to Org behaviour."
                         (insert (propertize
                                  (s-trim (s-replace "\n" " "
                                                     (plist-get props :content)))
-                                 'font-lock-face 'org-block
+                                 'font-lock-face 'org-roam-backlink
                                  'help-echo "mouse-1: visit backlinked note"
                                  'file-from file-from
                                  'file-from-point (plist-get props :point)))


### PR DESCRIPTION
I don't like org-block styling in backlinks buffer as it looks ugly
with my color scheme.

Add org-roam-backlink face for styling backlinks instead of using
org-block. It inherits from org-block, so that shouldn't affect the
default styling, but allows to override it without modifying
legitimate org-blocks.