### PR TITLE
(bugfix): Don't query about SQL proccess on Emacs exit

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -140,6 +140,7 @@ Performs a database upgrade when required."
            (init-db (not (file-exists-p db-file))))
       (make-directory (file-name-directory db-file) t)
       (let ((conn (emacsql-sqlite db-file)))
+        (set-process-query-on-exit-flag (emacsql-process conn) nil)
         (puthash (file-truename org-roam-directory)
                  conn
                  org-roam--db-connection)


### PR DESCRIPTION
Graceful shutdown is already guaranteed via `kill-emacs-hook`.

Refs #200

###### Motivation for this change

Prevents needless interaction on Emacs exit:

```
Active processes exist; kill them and exit anyway? (yes or no)
```