### PR TITLE
(feat): add optional initial-prompt to org-roam-find-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ templating system using `org-capture` is introduced.
 * [#232][gh-232] Adds a prefix key to `org-roam-show-graph`, to generate graph without opening it.
 * [#233][gh-233] Adds `org-roam-graph-exclude-matcher`, which allows exclusion of nodes from graph.
 * [#247][gh-247] Add `org-roam-backlink` face, which allows customizing backlinks appearance
+* [#259][gh-259] Add optional initial-prompt to `org-roam-find-file`
 
 ### Bugfixes
 * [#207][gh-207], [#221][gh-221] small bugfixes to Org-roam graph generation
@@ -121,6 +122,7 @@ Mostly a documentation/cleanup release.
 [gh-221]: https://github.com/jethrokuan/org-roam/pull/221
 [gh-230]: https://github.com/jethrokuan/org-roam/pull/230
 [gh-247]: https://github.com/jethrokuan/org-roam/pull/247
+[gh-259]: https://github.com/jethrokuan/org-roam/pull/259
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -796,11 +796,12 @@ point moves some characters forward. This is added as a hook to
                       file-path) res))))
     res))
 
-(defun org-roam-find-file ()
-  "Find and open an Org-roam file."
+(defun org-roam-find-file (&optional initial-prompt)
+  "Find and open an Org-roam file.
+INITIAL-PROMPT is the initial title prompt."
   (interactive)
   (let* ((completions (org-roam--get-title-path-completions))
-         (title (completing-read "File: " completions))
+         (title (completing-read "File: " completions nil nil initial-prompt))
          (file-path (cdr (assoc title completions))))
     (if file-path
         (find-file file-path)


### PR DESCRIPTION
###### Motivation for this change
Addresses #258.