### PR TITLE
(fix): Error if org-roam-insert is not called from Org-roam file

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -741,6 +741,8 @@ GOTO and KEYS argument have the same functionality as
   "Find an Org-roam file, and insert a relative org link to it at point.
 If PREFIX, downcase the title before insertion."
   (interactive "P")
+  (unless (org-roam--org-roam-file-p)
+    (user-error "Not in an Org-roam file"))
   (let* ((region (and (region-active-p)
                       ;; following may lose active region, so save it
                       (cons (region-beginning) (region-end))))


### PR DESCRIPTION
###### Motivation for this change

Not a fix to #262 , but a warning rather. `org-roam-insert` is meant to be called from an Org-roam file.