### PR TITLE
(fix): allow org-roam-insert in Org-roam file indirect buffers

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -741,7 +741,8 @@ GOTO and KEYS argument have the same functionality as
   "Find an Org-roam file, and insert a relative org link to it at point.
 If PREFIX, downcase the title before insertion."
   (interactive "P")
-  (unless (org-roam--org-roam-file-p)
+  (unless (org-roam--org-roam-file-p
+           (buffer-file-name (buffer-base-buffer)))
     (user-error "Not in an Org-roam file"))
   (let* ((region (and (region-active-p)
                       ;; following may lose active region, so save it


### PR DESCRIPTION
###### Motivation for this change
Fixing an issue with #264, where `org-roam-insert` stops working for capture templates.