### PR TITLE
(feat): add org-roam-graphviz-extra-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0 (TBD)
+
+## New Features
+* [#269][gh-269] Add `org-roam-graphviz-extra-options`
+
 ## 1.0.0-rc1 (06-03-2020)
 
 This is a pre-release before the push to MELPA. It contains large
@@ -123,6 +128,7 @@ Mostly a documentation/cleanup release.
 [gh-230]: https://github.com/jethrokuan/org-roam/pull/230
 [gh-247]: https://github.com/jethrokuan/org-roam/pull/247
 [gh-259]: https://github.com/jethrokuan/org-roam/pull/259
+[gh-259]: https://github.com/jethrokuan/org-roam/pull/269
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1096,6 +1096,13 @@ Valid states are 'visible, 'exists and 'none."
   :type 'string
   :group 'org-roam)
 
+(defcustom org-roam-graphviz-extra-options nil
+  "Extra options when contructing the Graphviz graph.
+Example:
+ '((\"rankdir\" . \"LR\"))"
+  :type '(alist)
+  :group 'org-roam)
+
 (defcustom org-roam-graph-max-title-length 100
   "Maximum length of titles in Graphviz graph nodes."
   :type 'number
@@ -1138,6 +1145,11 @@ into a digraph."
                     (org-roam-sql [:select :distinct [file-to file-from]
                                    :from file-links]))))
 	    (insert "digraph \"org-roam\" {\n")
+      (dolist (option org-roam-graphviz-extra-options)
+        (insert (concat (car option)
+                        "="
+                        (cdr option)
+                        ";\n")))
       (dolist (node nodes)
         (let* ((file (xml-escape-string (car node)))
                (title (or (caadr node)


### PR DESCRIPTION
###### Motivation for this change

Add `org-roam-graphviz-extra-options` which allows passing of extra options during Graphviz graph generation.

Ref #263 