### PR TITLE
(docs):fix typo in platypus installation

### DIFF
--- a/doc/roam_protocol.md
+++ b/doc/roam_protocol.md
@@ -102,7 +102,7 @@ instructions for setting up with Platypus and Chrome:
 1. Install and launch Platypus (with [Homebrew](https://brew.sh/)):
 
 ```sh
-brew cask install playtpus
+brew cask install platypus
 ```
 2. Create a script `launch_emacs.sh`:
 


### PR DESCRIPTION
###### Motivation for this change
fix typo in MacOS platypus installation.