### PR TITLE
(bugfix): propagate org-roam-directory to temp buffers

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -426,8 +426,8 @@ https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff728
       ret)))
 
 (defmacro org-roam--with-temp-buffer (&rest body)
-  "Call \"with-temp-buffer\", propagating \"org-roam-directory\"
-to the temp buffer."
+  "Call `with-temp-buffer`, propagating `org-roam-directory` to
+the temp buffer."
   (declare (indent 0) (debug t))
   (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))
     `(let ((,current-org-roam-directory org-roam-directory))

--- a/org-roam.el
+++ b/org-roam.el
@@ -340,7 +340,7 @@ This is equivalent to removing the node from the graph."
          (time (current-time))
          all-files all-links all-titles all-refs)
     (dolist (file org-roam-files)
-      (with-temp-buffer
+      (with-org-roam-temp-buffer
         (insert-file-contents file)
         (let ((contents-hash (secure-hash 'sha1 (current-buffer))))
           (unless (string= (gethash file current-files)
@@ -424,6 +424,16 @@ https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff728
                                   lst)))
           (setq ret (append ret str-list2))))
       ret)))
+
+(defmacro with-org-roam-temp-buffer (&rest body)
+  "Call with-temp-buffer, propagating org-roam-directory to the
+temp buffer."
+  (declare (indent 0) (debug t))
+  (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))
+    `(let ((,current-org-roam-directory org-roam-directory))
+       (with-temp-buffer
+         (let ((org-roam-directory ,current-org-roam-directory))
+           ,@body)))))
 
 ;;;; File functions and predicates
 (defun org-roam--touch-file (path)
@@ -1101,7 +1111,7 @@ The Org-roam database titles table is read, to obtain the list of titles.
 The file-links table is then read to obtain all directed links, and formatted
 into a digraph."
   (org-roam--db-ensure-built)
-  (with-temp-buffer
+  (with-org-roam-temp-buffer
     (let* ((matcher (concat "%" org-roam-graph-exclude-matcher "%"))
            (nodes (if org-roam-graph-exclude-matcher
                       (org-roam-sql [:select [file titles]

--- a/org-roam.el
+++ b/org-roam.el
@@ -340,7 +340,7 @@ This is equivalent to removing the node from the graph."
          (time (current-time))
          all-files all-links all-titles all-refs)
     (dolist (file org-roam-files)
-      (with-org-roam-temp-buffer
+      (org-roam--with-temp-buffer
         (insert-file-contents file)
         (let ((contents-hash (secure-hash 'sha1 (current-buffer))))
           (unless (string= (gethash file current-files)
@@ -425,9 +425,9 @@ https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff728
           (setq ret (append ret str-list2))))
       ret)))
 
-(defmacro with-org-roam-temp-buffer (&rest body)
-  "Call with-temp-buffer, propagating org-roam-directory to the
-temp buffer."
+(defmacro org-roam--with-temp-buffer (&rest body)
+  "Call \"with-temp-buffer\", propagating \"org-roam-directory\"
+to the temp buffer."
   (declare (indent 0) (debug t))
   (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))
     `(let ((,current-org-roam-directory org-roam-directory))
@@ -1111,7 +1111,7 @@ The Org-roam database titles table is read, to obtain the list of titles.
 The file-links table is then read to obtain all directed links, and formatted
 into a digraph."
   (org-roam--db-ensure-built)
-  (with-org-roam-temp-buffer
+  (org-roam--with-temp-buffer
     (let* ((matcher (concat "%" org-roam-graph-exclude-matcher "%"))
            (nodes (if org-roam-graph-exclude-matcher
                       (org-roam-sql [:select [file titles]

--- a/org-roam.el
+++ b/org-roam.el
@@ -426,7 +426,7 @@ https://github.com/kaushalmodi/ox-hugo/blob/a80b250987bc770600c424a10b3bca6ff728
       ret)))
 
 (defmacro org-roam--with-temp-buffer (&rest body)
-  "Call `with-temp-buffer`, propagating `org-roam-directory` to
+  "Call `with-temp-buffer', propagating `org-roam-directory' to
 the temp buffer."
   (declare (indent 0) (debug t))
   (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))


### PR DESCRIPTION
###### Motivation for this change
Fixes rebuilding the database and creating the graph when `org-roam-directory` is overridden by .`dir-locals.el`.