### PR TITLE
Customizable org-roam-completion-system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## New Features
 * [#269][gh-269] Add `org-roam-graphviz-extra-options`
 * [#257][gh-257] Add a company-backend `company-org-roam`
+* [#284][gh-284] Configurable `org-roam-completion-system` with options `'default` and `'helm`
 
 ## 1.0.0-rc1 (06-03-2020)
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -107,3 +107,16 @@ SVG, you may choose to set it to any compatible program:
 ```
 (setq org-roam-graph-viewer "/path/to/image-viewer")
 ```
+
+## Org-roam Completion System
+
+Org-roam offers completion when choosing note titles etc.
+The completion system is configurable. The default setting,
+```
+(setq org-roam-completion-system 'default)
+```
+uses Emacs' standard `completing-read`. If you prefer [Helm](https://emacs-helm.github.io/helm/), use
+
+```
+(setq org-roam-completion-system 'helm)
+```

--- a/org-roam.el
+++ b/org-roam.el
@@ -622,14 +622,16 @@ Return user choice."
                  (fboundp 'helm-build-sync-source))
       (user-error "Please install helm from \
 https://github.com/emacs-helm/helm"))
-    (let* ((source (helm-build-sync-source "Title"
+    (let* ((source (helm-build-sync-source prompt
                      :candidates (-map #'car choices)
                      :filtered-candidate-transformer
                      (and (not require-match)
                           #'org-roam---helm-candidate-transformer)
                      :fuzzy-match t))
            (title (helm :sources source
-                        :buffer "*org-roam titles*"
+                        :buffer (concat "*org-roam "
+                                        (s-downcase (s-chop-suffix ":" (s-trim prompt)))
+                                        "*")
                         :prompt prompt
                         :input initial-input)))
       (unless title
@@ -913,7 +915,7 @@ INFO is an alist containing additional information."
                                     roam-buffers)))
     (unless roam-buffers
       (user-error "No roam buffers"))
-    (when-let ((name (org-roam--completing-read "Choose a buffer: " names-and-buffers t)))
+    (when-let ((name (org-roam--completing-read "Buffer: " names-and-buffers t)))
       (switch-to-buffer (cdr (assoc name names-and-buffers))))))
 
 ;;;; Daily notes


### PR DESCRIPTION
Currently implemented choices:
 - `'default` for Emacs' `completing-read`
 - `'helm` for Helm

###### Motivation for this change
