### PR TITLE
(feat): add org-roam-date-title-format and org-roam-date-filename-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#257][gh-257] Add a company-backend `company-org-roam`
 * [#284][gh-284], [#289][gh-289] Configurable `org-roam-completion-system` with options `'default`, `'ido`, `'ivy` and `'helm`.
 * [#289][gh-289] Add customizable `org-roam-fuzzy-match` to allow fuzzy-matching of candidates
+* [#290][gh-290] Add `org-roam-date-title-format` and `org-roam-date-filename-format` for customizing Org-roam's date files
 
 ## 1.0.0-rc1 (06-03-2020)
 
@@ -135,6 +136,7 @@ Mostly a documentation/cleanup release.
 [gh-269]: https://github.com/jethrokuan/org-roam/pull/269
 [gh-284]: https://github.com/jethrokuan/org-roam/pull/284
 [gh-289]: https://github.com/jethrokuan/org-roam/pull/289
+[gh-290]: https://github.com/jethrokuan/org-roam/pull/290
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -860,7 +860,9 @@ If PREFIX, downcase the title before insertion."
     (with-current-buffer buf
       (when region ;; Remove previously selected text.
         (delete-region (car region) (cdr region)))
-      (let ((link-location (concat "file:" (file-relative-name target-file-path current-file-path)))
+      (let ((link-location (concat "file:"
+                                   (file-relative-name target-file-path
+                                                       current-file-path)))
             (description (org-roam--format-link-title (if prefix
                                                           (downcase region-or-title)
                                                         region-or-title))))
@@ -957,10 +959,17 @@ INFO is an alist containing additional information."
       (switch-to-buffer (cdr (assoc name names-and-buffers))))))
 
 ;;;; Daily notes
+(defcustom org-roam-date-title-format "%Y-%m-%d"
+  "Format string passed to `format-time-string' for getting a date file's title.")
+
+(defcustom org-roam-date-filename-format "%Y-%m-%d"
+  "Format string passed to `format-time-string' for getting a date file's filename.")
+
 (defun org-roam--file-for-time (time)
   "Create and find file for TIME."
-  (let* ((title (format-time-string "%Y-%m-%d" time))
-         (file-path (org-roam--file-path-from-id title)))
+  (let* ((title (format-time-string org-roam-date-title-format time))
+         (filename (format-time-string org-roam-date-filename-format time))
+         (file-path (org-roam--file-path-from-id filename)))
     (if (file-exists-p file-path)
         file-path
       (let ((org-roam-capture-templates (list (list "d" "daily" 'plain (list 'function #'org-roam--capture-get-point)


### PR DESCRIPTION
###### Motivation for this change

This PR supercedes #280. It allows users who use the date
functionality in Org-roam to customize the filename and title formats
of the created files.

Closes #280 and closes #277 