### PR TITLE
Less abusive use of org-capture - proof of concept

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -801,8 +801,6 @@ This function is used solely in Org-roam's capture templates: see
        (goto-char (point-max))))
     (_ (error "Invalid org-roam-capture-context"))))
 
-(defvar org-roam--capture-immediate-finish)
-
 (defun org-roam-capture (&optional goto keys)
   "Create a new file, and return the path to the edited file.
 The templates are defined at `org-roam-capture-templates'.  The
@@ -812,9 +810,7 @@ GOTO and KEYS argument have the same functionality as
         file-path)
     (when (= (length org-capture-templates) 1)
       (setq keys (caar org-capture-templates)))
-    (setq org-roam--capture-immediate-finish goto)
-    (org-capture nil keys)
-    ))
+    (org-capture nil keys)))
 
 ;;; Interactive Commands
 ;;;; org-roam-insert
@@ -925,7 +921,7 @@ INITIAL-PROMPT is the initial title prompt."
       (let* ((org-roam--capture-info (list (cons 'title title)
                                            (cons 'slug (org-roam--title-to-slug title))))
              (org-roam--capture-context 'title))
-        (org-roam-capture t)
+        (org-roam-capture)
         (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file)))))
 
 ;;;; org-roam-find-ref

--- a/org-roam.el
+++ b/org-roam.el
@@ -762,7 +762,6 @@ currently active Org-roam template."
          (file-path (org-roam--file-path-from-id new-id)))
     (when (file-exists-p file-path)
       (error (format "File exists at %s, aborting" file-path)))
-    (org-roam--touch-file file-path)
     file-path))
 
 (defun org-roam--capture-get-point ()
@@ -782,10 +781,8 @@ This function is used solely in Org-roam's capture templates: see
                     (org-roam--fill-template (or (org-capture-get :head)
                                                  org-roam--capture-header-default)
                                              org-roam--capture-info)
-                    "\n" (org-capture-get :template)))
-
-  (org-capture-put :immediate-finish org-roam--capture-immediate-finish)
-
+                    "\n" (org-capture-get :template))
+                   :type 'plain)
   (pcase org-roam--capture-context
     ('title
      (let ((file-path (org-roam--capture-new-file)))
@@ -891,7 +888,6 @@ point moves some characters forward.  This is added as a hook to
     (setq org-roam--capture-insert-point nil)))
 
 (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-advance-point)
-(add-hook 'org-capture-after-finalize-hook (lambda () (when org-roam--capture-immediate-finish (switch-to-buffer (find-buffer-visiting org-roam--capture-file-path)))))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
@@ -930,7 +926,7 @@ INITIAL-PROMPT is the initial title prompt."
                                            (cons 'slug (org-roam--title-to-slug title))))
              (org-roam--capture-context 'title))
         (org-roam-capture t)
-        (setq org-roam--capture-file-path nil)))))
+        (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file)))))
 
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -763,12 +763,6 @@ currently active Org-roam template."
     (when (file-exists-p file-path)
       (error (format "File exists at %s, aborting" file-path)))
     (org-roam--touch-file file-path)
-    (write-region
-     (org-roam--fill-template (or (org-capture-get :head)
-                                  org-roam--capture-header-default)
-                              org-roam--capture-info)
-     nil file-path nil)
-    (sleep-for 0.2)  ;; Hack: expand-file-name stringp nil error sporadically otherwise
     file-path))
 
 (defun org-roam--capture-get-point ()
@@ -783,6 +777,15 @@ If there is no file with that ref, a file with that ref is created.
 
 This function is used solely in Org-roam's capture templates: see
 `org-roam-capture-templates'."
+  (org-capture-put :template
+                   (concat
+                    (org-roam--fill-template (or (org-capture-get :head)
+                                                 org-roam--capture-header-default)
+                                             org-roam--capture-info)
+                    "\n" (org-capture-get :template)))
+
+  (org-capture-put :immediate-finish org-roam--capture-immediate-finish)
+
   (pcase org-roam--capture-context
     ('title
      (let ((file-path (org-roam--capture-new-file)))
@@ -801,6 +804,8 @@ This function is used solely in Org-roam's capture templates: see
        (goto-char (point-max))))
     (_ (error "Invalid org-roam-capture-context"))))
 
+(defvar org-roam--capture-immediate-finish)
+
 (defun org-roam-capture (&optional goto keys)
   "Create a new file, and return the path to the edited file.
 The templates are defined at `org-roam-capture-templates'.  The
@@ -810,10 +815,9 @@ GOTO and KEYS argument have the same functionality as
         file-path)
     (when (= (length org-capture-templates) 1)
       (setq keys (caar org-capture-templates)))
-    (org-capture goto keys)
-    (setq file-path org-roam--capture-file-path)
-    (setq org-roam--capture-file-path nil)
-    file-path))
+    (setq org-roam--capture-immediate-finish goto)
+    (org-capture nil keys)
+    ))
 
 ;;; Interactive Commands
 ;;;; org-roam-insert
@@ -856,7 +860,9 @@ If PREFIX, downcase the title before insertion."
       (let* ((org-roam--capture-info (list (cons 'title title)
                                            (cons 'slug (org-roam--title-to-slug title))))
              (org-roam--capture-context 'title))
-        (setq target-file-path (org-roam-capture))))
+        (org-roam-capture)
+        (setq target-file-path org-roam--capture-file-path)
+        (setq org-roam--capture-file-path nil)))
     (with-current-buffer buf
       (when region ;; Remove previously selected text.
         (delete-region (car region) (cdr region)))
@@ -882,8 +888,10 @@ point moves some characters forward.  This is added as a hook to
 `org-capture-after-finalize-hook'."
   (when org-roam--capture-insert-point
     (goto-char org-roam--capture-insert-point)
-    (setq org-roam--capture-insert-point nil))
-  (remove-hook 'org-capture-after-finalize-hook #'org-roam--capture-advance-point))
+    (setq org-roam--capture-insert-point nil)))
+
+(add-hook 'org-capture-after-finalize-hook #'org-roam--capture-advance-point)
+(add-hook 'org-capture-after-finalize-hook (lambda () (when org-roam--capture-immediate-finish (switch-to-buffer (find-buffer-visiting org-roam--capture-file-path)))))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
@@ -921,8 +929,8 @@ INITIAL-PROMPT is the initial title prompt."
       (let* ((org-roam--capture-info (list (cons 'title title)
                                            (cons 'slug (org-roam--title-to-slug title))))
              (org-roam--capture-context 'title))
-        (setq org-roam--capture-file-path (org-roam-capture))
-        (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file)))))
+        (org-roam-capture t)
+        (setq org-roam--capture-file-path nil)))))
 
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -781,7 +781,7 @@ This function is used solely in Org-roam's capture templates: see
                     (org-roam--fill-template (or (org-capture-get :head)
                                                  org-roam--capture-header-default)
                                              org-roam--capture-info)
-                    "\n" (org-capture-get :template))
+                    (org-capture-get :template))
                    :type 'plain)
   (pcase org-roam--capture-context
     ('title
@@ -810,7 +810,7 @@ GOTO and KEYS argument have the same functionality as
         file-path)
     (when (= (length org-capture-templates) 1)
       (setq keys (caar org-capture-templates)))
-    (org-capture nil keys)))
+    (org-capture goto keys)))
 
 ;;; Interactive Commands
 ;;;; org-roam-insert

--- a/org-roam.el
+++ b/org-roam.el
@@ -881,9 +881,8 @@ point moves some characters forward.  This is added as a hook to
 `org-capture-after-finalize-hook'."
   (when org-roam--capture-insert-point
     (goto-char org-roam--capture-insert-point)
-    (setq org-roam--capture-insert-point nil)))
-
-(add-hook 'org-capture-after-finalize-hook #'org-roam--capture-advance-point)
+    (setq org-roam--capture-insert-point nil))
+  (remove-hook 'org-capture-after-finalize-hook #'org-roam--capture-advance-point))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()


### PR DESCRIPTION
###### What's changed

- `org-roam--capture-new-file` does not write anything to a file, all the
   templating is delegated to vanilla `org-capture`.
- `org-roam--capture-get-point` injects the desired template adjustments and
   behavior using `org-capture-put`
- `org-roam-capture-templates` variables work as before
- `org-capture-templates` wildcards work as intended except for "%?"
- depending functions adjusted accordingly
- new variable to `org-roam--capture-immediate-finish` to control the capture
  process finishing unattended

###### Proof of concept

1. The original org-roam behaviour as presented to the end user did not change.
2. The changes, however, have not been thoroughly tested, so some things may not work.
3. Point is not set as indicated by "%?" in a template, this must be fixed.

###### Motivation for this change

1. The main idea is to use the `:target` property of `org-capture-templates` as designed by `org-capture`, that is 

> Most general way: write your own function which both visits the file and moves point to the right location.

See: https://orgmode.org/manual/Template-elements.html#Template-elements

2. This will ensure compatibility of org-roam and org-capture in the future.
3. The suggested changes also allow to use both `org-roam-capture-templates` and `org-capture-templates` goodies transparently.

###### Original discussion

https://github.com/jethrokuan/org-roam/issues/285