### PR TITLE
(feat): upgrade `org-roam-graph-exclude-matcher` to accept a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#284][gh-284], [#289][gh-289] Configurable `org-roam-completion-system` with options `'default`, `'ido`, `'ivy` and `'helm`.
 * [#289][gh-289] Add customizable `org-roam-fuzzy-match` to allow fuzzy-matching of candidates
 * [#290][gh-290] Add `org-roam-date-title-format` and `org-roam-date-filename-format` for customizing Org-roam's date files
+* [#296][gh-296] Allow multiple exclusion matchers in `org-roam-graph-exclude-matcher`
 
 ## Bugfixes
 * [#293][gh-293] Fix capture templates not working as expected for `org-roam-find-file`
@@ -141,6 +142,7 @@ Mostly a documentation/cleanup release.
 [gh-289]: https://github.com/jethrokuan/org-roam/pull/289
 [gh-290]: https://github.com/jethrokuan/org-roam/pull/290
 [gh-293]: https://github.com/jethrokuan/org-roam/pull/293
+[gh-296]: https://github.com/jethrokuan/org-roam/pull/296
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -115,15 +115,28 @@ SVG, you may choose to set it to any compatible program:
 (setq org-roam-graph-viewer "/path/to/image-viewer")
 ```
 
+### Excluding Nodes and Edges
+One may want to exclude certain files to declutter the graph. You can do so by setting `org-roam-graph-exclude-matcher`.
+
+```
+(setq org-roam-graph-exclude-matcher '("private" "dailies"))
+```
+
+This setting excludes all files whose path contain "private" or "dailies".
+
 ## Org-roam Completion System
 
 Org-roam offers completion when choosing note titles etc.
 The completion system is configurable. The default setting,
+
 ```
 (setq org-roam-completion-system 'default)
 ```
+
 uses Emacs' standard `completing-read`. If you prefer [Helm](https://emacs-helm.github.io/helm/), use
 
 ```
 (setq org-roam-completion-system 'helm)
 ```
+
+Other options included `'ido`, and `'ivy'`.


### PR DESCRIPTION
###### Motivation for this change
Closes #295.

Now `org-roam-graph-exclude-matcher` takes a list of strings.