### PR TITLE
hexify file url for org-protocol link

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1301,7 +1301,7 @@ into a digraph."
                    file
 				           (xml-escape-string shortened-title)
 				           org-roam-graph-node-shape
-				           file
+				           (url-hexify-string file)
 				           (xml-escape-string title)))))
       (dolist (edge edges)
         (insert (format "  \"%s\" -> \"%s\";\n"


### PR DESCRIPTION
The org-roam graph would not link properly through org-protocol when using the Emacs Mac Port. This did address the issue. For your consideration, please.