### PR TITLE
(bugfix): capture: prepend header template only on new file

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -751,9 +751,16 @@ Next, it expands the remaining template string using
       (org-capture-fill-template)))
 
 (defun org-roam--capture-new-file ()
-  "Create a new file and return the file path.
-This is achieved by reading the file-name attribute of the
-currently active Org-roam template."
+  "Return the path to the new file during an Org-roam capture.
+
+This function reads the file-name attribute of the currently
+active Org-roam template.
+
+If the file path already exists, it throw an error.
+
+Else, to insert the header content in the file, org-capture
+template is prepended with the `:head' portion of the Org-roam
+capture template."
   (let* ((name-templ (or (org-capture-get :file-name)
                          org-roam--capture-file-name-default))
          (new-id (s-trim (org-roam--fill-template
@@ -762,7 +769,20 @@ currently active Org-roam template."
          (file-path (org-roam--file-path-from-id new-id)))
     (when (file-exists-p file-path)
       (error (format "File exists at %s, aborting" file-path)))
+    (org-capture-put :template
+                     (concat
+                      (or (org-capture-get :head)
+                          org-roam--capture-header-default)
+                      (org-capture-get :template))
+                     :type 'plain)
     file-path))
+
+(defun org-roam--expand-capture-template ()
+  "Expand capture template with information from `org-roam--capture-info'."
+  (org-capture-put :template
+                   (s-format (org-capture-get :template) (lambda (key)
+                  (or (s--aget org-roam--capture-info key)
+                      (completing-read (format "%s: " key ) nil))) nil)))
 
 (defun org-roam--capture-get-point ()
   "Return exact point to file for org-capture-template.
@@ -776,16 +796,10 @@ If there is no file with that ref, a file with that ref is created.
 
 This function is used solely in Org-roam's capture templates: see
 `org-roam-capture-templates'."
-  (org-capture-put :template
-                   (concat
-                    (org-roam--fill-template (or (org-capture-get :head)
-                                                 org-roam--capture-header-default)
-                                             org-roam--capture-info)
-                    (org-capture-get :template))
-                   :type 'plain)
   (pcase org-roam--capture-context
     ('title
      (let ((file-path (org-roam--capture-new-file)))
+       (org-roam--expand-capture-template)
        (setq org-roam--capture-file-path file-path)
        (set-buffer (org-capture-target-buffer file-path))
        (widen)
@@ -795,6 +809,7 @@ This function is used solely in Org-roam's capture templates: see
             (ref (cdr (assoc 'ref org-roam--capture-info)))
             (file-path (or (cdr (assoc ref completions))
                            (org-roam--capture-new-file))))
+       (org-roam--expand-capture-template)
        (setq org-roam--capture-file-path file-path)
        (set-buffer (org-capture-target-buffer file-path))
        (widen)


### PR DESCRIPTION
###### Motivation for this change

#294 introduced a bug where header templates are injected on every capture call. This happens to be fine for `org-roam-find-file`, and `org-roam-insert`, but this breaks the capture system for references.