### PR TITLE
(bugfix): fix ugly node labels in org-roam graph

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1315,7 +1315,7 @@ into a digraph."
           (insert
 		       (format "  \"%s\" [label=\"%s\", shape=%s, URL=\"org-protocol://roam-file?file=%s\", tooltip=\"%s\"];\n"
                    file
-				           (xml-escape-string shortened-title)
+				           (s-replace "\"" "\\\"" shortened-title)
 				           org-roam-graph-node-shape
 				           (url-hexify-string file)
 				           (xml-escape-string title)))))


### PR DESCRIPTION
###### Motivation for this change
Node labels on certain note titles are ugly. `'` gets escaped to `&apros;`