### PR TITLE
(feat): clean-ups for org-roam-capture system

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -940,13 +940,12 @@ This is added as a hook to `org-capture-after-finalize-hook'."
                       file-path) res))))
     res))
 
-(defun org-roam--capture-find-file ()
+(defun org-roam--capture-find-file-h ()
   "Opens the newly created template file.
 This is added as a hook to `org-capture-after-finalize-hook'."
-  (when org-roam--capture-file-path
-    (find-file org-roam--capture-file-path)
-    (setq org-roam--capture-file-path nil))
-  (remove-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file))
+  (when-let ((file-path (org-capture-get :roam-file-path)))
+    (find-file file-path))
+  (remove-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file-h))
 
 (defun org-roam-find-file (&optional initial-prompt)
   "Find and open an Org-roam file.
@@ -961,8 +960,8 @@ INITIAL-PROMPT is the initial title prompt."
       (let* ((org-roam--capture-info (list (cons 'title title)
                                            (cons 'slug (org-roam--title-to-slug title))))
              (org-roam--capture-context 'title))
-        (org-roam-capture)
-        (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file)))))
+        (add-hook 'org-capture-after-finalize-hook #'org-roam--capture-find-file-h)
+        (org-roam-capture)))))
 
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -115,7 +115,14 @@
           (before-each
            (org-roam--test-init)
            (org-roam--db-clear)
-           (org-roam-build-cache))
+           (org-roam-build-cache)
+           (setq org-roam-capture-templates
+                 '(("d" "default" plain (function org-roam--capture-get-point)
+                    "%?"
+                    :file-name "%<%Y%m%d%H%M%S>-${slug}"
+                    :head "#+TITLE: ${title}\n"
+                    :unnarrowed t
+                    :immediate-finish t))))
 
           (it "temp1 -> foo"
               (let ((buf (org-roam--test-find-new-file "temp1.org")))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -115,14 +115,7 @@
           (before-each
            (org-roam--test-init)
            (org-roam--db-clear)
-           (org-roam-build-cache)
-           (setq org-roam-capture-templates
-                 '(("d" "default" plain (function org-roam--capture-get-point)
-                    "%?"
-                    :file-name "%<%Y%m%d%H%M%S>-${slug}"
-                    :head "#+TITLE: ${title}\n"
-                    :unnarrowed t
-                    :immediate-finish t))))
+           (org-roam-build-cache))
 
           (it "temp1 -> foo"
               (let ((buf (org-roam--test-find-new-file "temp1.org")))


### PR DESCRIPTION
##### Motivation for this change

Addresses #310.

This introduces 2 user-facing changes:

1. If a capture process is aborted, the file is not created if it
doesn't yet exist

2. If a capture process is aborted, org-roam-insert will not insert a
link
