### PR TITLE
For `ido-completing-read', `choices' must be a list of strings.

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -629,7 +629,8 @@ Return user choice."
     (setq res
           (cond
            ((eq org-roam-completion-system 'ido)
-            (ido-completing-read prompt choices nil require-match initial-input))
+	    (let ((candidates (mapcar #'car choices)))
+	      (ido-completing-read prompt candidates nil require-match initial-input)))
            ((eq org-roam-completion-system 'default)
             (completing-read prompt choices nil require-match initial-input))
            ((eq org-roam-completion-system 'ivy)

--- a/org-roam.el
+++ b/org-roam.el
@@ -629,8 +629,8 @@ Return user choice."
     (setq res
           (cond
            ((eq org-roam-completion-system 'ido)
-	    (let ((candidates (mapcar #'car choices)))
-	      (ido-completing-read prompt candidates nil require-match initial-input)))
+            (let ((candidates (mapcar #'car choices)))
+              (ido-completing-read prompt candidates nil require-match initial-input)))
            ((eq org-roam-completion-system 'default)
             (completing-read prompt choices nil require-match initial-input))
            ((eq org-roam-completion-system 'ivy)


### PR DESCRIPTION
When `org-roam-completion-system` is set to `ido`, the following errors occur:
* After `M-x org-roam-switch-to-buffer`:
  > Error in post-command-hook (ido-exhibit): (wrong-type-argument sequencep #\<buffer filename.org>)
* When hitting tab after `M-x org-roam-find-file`:
  > ido-file-lessp: Wrong type argument: listp, "/path/to/filename.org"

These errors occur because `ido-completing-read` can only deal with a list of strings. Suggested fix: Only pass the names.