### PR TITLE
(internal): force a reconnect on org-roam-build-cache

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -360,6 +360,7 @@ This is equivalent to removing the node from the graph."
 (defun org-roam-build-cache ()
   "Build the cache for `org-roam-directory'."
   (interactive)
+  (org-roam--db-close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
   (let* ((org-roam-files (org-roam--list-files org-roam-directory))
          (current-files (org-roam--get-current-files))


### PR DESCRIPTION
###### Motivation for this change
This is to guard against scenarios where a db connection is still live, although it may already be invalid. Closes #331