### PR TITLE
(chore): update internal Github settings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [jethrokuan]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 26.3
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
Removes sponsor button, and disables 26.3 in testing matrix