### PR TITLE
(feat): add variable for muting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 * [#350][gh-350] Add `org-roam-db-location`
+* [#359][gh-359] Add `org-roam-verbose`
 
 ## 1.0.0 (23-03-2020)
 
@@ -154,6 +155,7 @@ Mostly a documentation/cleanup release.
 [gh-293]: https://github.com/jethrokuan/org-roam/pull/293
 [gh-296]: https://github.com/jethrokuan/org-roam/pull/296
 [gh-350]: https://github.com/jethrokuan/org-roam/pull/350
+[gh-359]: https://github.com/jethrokuan/org-roam/pull/359
 
  # Local Variables:
  # eval: (auto-fill-mode -1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -129,6 +129,11 @@ Formatter may be a function that takes title as its only argument."
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")
 
+(defcustom org-roam-verbose t
+  "Echo messages that are not errors."
+  :type 'boolean
+  :group 'org-roam)
+
 ;;; Database
 ;;;; Options
 (defcustom org-roam-db-location nil
@@ -423,12 +428,13 @@ This is equivalent to removing the node from the graph."
                        :titles (length all-titles)
                        :refs (length all-refs)
                        :deleted (length (hash-table-keys current-files)))))
-      (message "files: %s, links: %s, titles: %s, refs: %s, deleted: %s"
-               (plist-get stats :files)
-               (plist-get stats :links)
-               (plist-get stats :titles)
-               (plist-get stats :refs)
-               (plist-get stats :deleted))
+      (when org-roam-verbose
+        (message "files: %s, links: %s, titles: %s, refs: %s, deleted: %s"
+                 (plist-get stats :files)
+                 (plist-get stats :links)
+                 (plist-get stats :titles)
+                 (plist-get stats :refs)
+                 (plist-get stats :deleted)))
       stats)))
 
 ;;; Utilities


### PR DESCRIPTION
###### Motivation for this change

Adds `org-roam-verbose`, which echoes messages that are not errors.

Fixes #356 .


