### PR TITLE
(fix): Add alias for 'org-roam--capture-get-point

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -233,6 +233,8 @@ the file if the original value of :no-save is not t and
                                (or (s--aget org-roam-capture--info key)
                                    (completing-read (format "%s: " key ) nil))) nil)))
 
+(defalias 'org-roam--capture-get-point 'org-roam-capture--get-point)
+(make-obsolete 'org-roam--capture-get-point 'org-roam-capture--get-point "2020/03/29")
 (defun org-roam-capture--get-point ()
   "Return exact point to file for org-capture-template.
 The file to use is dependent on the context:


### PR DESCRIPTION
This ensures custom templates don't break