### PR TITLE
(feat): Add interactive org-roam-capture

### DIFF
--- a/doc/templating.md
+++ b/doc/templating.md
@@ -27,7 +27,7 @@ additional properties:
 
 Org-roam's template definitions also extend org-capture's template
 syntax, to allow prefilling of strings. In many scenarios,
-`org-roam-capture` is passed a mapping between variables and strings.
+`org-roam--capture` is passed a mapping between variables and strings.
 For example, during `org-roam-insert`, a title is prompted for. If the
 title doesn't already exist, we would like to create a new file,
 without prompting for the title again.
@@ -67,7 +67,7 @@ Here I walkthrough the default template, reproduced below.
 3. `plain` text is inserted. Other options include Org headings via
    `entry`.
 4. `(function org-roam--capture-get-point)` should not be changed.
-5. `"%?"` is the template inserted on each call to `org-roam-capture`.
+5. `"%?"` is the template inserted on each call to `org-roam--capture`.
    This template means don't insert any content, but place the cursor
    here.
 6. `:file-name` is the file-name template for a new note, if it

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -248,6 +248,9 @@ If there is no file with that ref, a file with that ref is created.
 This function is used solely in Org-roam's capture templates: see
 `org-roam-capture-templates'."
   (let ((file-path (pcase org-roam-capture--context
+                     ('capture
+                      (or (cdr (assoc 'file org-roam-capture--info))
+                          (org-roam-capture--new-file)))
                      ('title
                       (org-roam-capture--new-file))
                      ('ref
@@ -290,7 +293,7 @@ This function is used solely in Org-roam's capture templates: see
         (push val converted)))
     (append (nreverse converted) `(:org-roam ,org-roam-plist))))
 
-(defun org-roam-capture (&optional goto keys)
+(defun org-roam--capture (&optional goto keys)
   "Create a new file, and return the path to the edited file.
 The templates are defined at `org-roam-capture-templates'.  The
 GOTO and KEYS argument have the same functionality as

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -62,7 +62,7 @@ It opens or creates a note with the given ref.
            (org-roam-capture--info decoded-alist)
            (template (cdr (assoc 'template decoded-alist))))
       (raise-frame)
-      (org-roam-capture nil template)
+      (org-roam--capture nil template)
       (message "Item captured.")))
   nil)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -349,7 +349,7 @@ If PREFIX, downcase the title before insertion."
           (setq org-roam-capture-additional-template-props (list :region region
                                                                  :link-description link-description
                                                                  :capture-fn 'org-roam-insert))
-          (org-roam-capture))))))
+          (org-roam--capture))))))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
@@ -382,7 +382,7 @@ INITIAL-PROMPT is the initial title prompt."
                                             (cons 'slug (org-roam--title-to-slug title))))
               (org-roam-capture--context 'title))
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-          (org-roam-capture))))))
+          (org-roam--capture))))))
 
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()
@@ -427,6 +427,23 @@ INFO is an alist containing additional information."
                                                            :require-match t)))
       (switch-to-buffer (cdr (assoc name names-and-buffers))))))
 
+;;;; org-roam-capture
+(defun org-roam-capture ()
+  "Launches an org-capture process for a new or existing note.
+This uses the templates defined at `org-roam-capture-templates'."
+  (interactive)
+  (when org-roam-capture--in-process
+    (user-error "Nested Org-roam capture processes not supported"))
+  (let* ((completions (org-roam--get-title-path-completions))
+         (title (org-roam-completion--completing-read "File: " completions))
+         (file-path (cdr (assoc title completions))))
+    (let ((org-roam-capture--info (list (cons 'title title)
+                                            (cons 'slug (org-roam--title-to-slug title))
+                                            (cons 'file file-path)))
+              (org-roam-capture--context 'capture))
+          (setq org-roam-capture-additional-template-props (list :capture-fn 'org-roam-capture))
+          (org-roam--capture))))
+
 ;;;; Daily notes
 (defcustom org-roam-date-title-format "%Y-%m-%d"
   "Format string passed to `format-time-string' for getting a date file's title."
@@ -463,7 +480,7 @@ INFO is an alist containing additional information."
             (org-roam-capture--info (list (cons 'title title)
                                           (cons 'filename filename))))
         (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-        (org-roam-capture)))))
+        (org-roam--capture)))))
 
 (defun org-roam-today ()
   "Create and find file for today."


### PR DESCRIPTION
###### Motivation for this change

Adds an interactive function `org-roam-capture`, which captures information into new or existing notes.