### PR TITLE
(hotfix): move capture in-process setting as late as possible

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -265,6 +265,7 @@ This function is used solely in Org-roam's capture templates: see
       (let ((prop (pop org-roam-capture-additional-template-props))
             (val (pop org-roam-capture-additional-template-props)))
         (org-roam-capture--put prop val)))
+    (setq org-roam-capture--in-process t)
     (set-buffer (org-capture-target-buffer file-path))
     (widen)
     (goto-char (point-max))))
@@ -303,7 +304,6 @@ GOTO and KEYS argument have the same functionality as
       (setq keys (caar org-capture-templates)))
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--save-file-maybe-h)
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--cleanup-h 10)
-    (setq org-roam-capture--in-process t)
     (org-capture goto keys)))
 
 (provide 'org-roam-capture)


### PR DESCRIPTION
###### Motivation for this change

This is a hotfix for #369. Currently, calling `org-roam-capture` sets
`org-roam-capture--in-process` to `t`, but cancelling the capture
process does not reset it to `nil`, causing false errors. The whole
nested org-capture processes workaround is brittle, this change moves it
as far back as possible, but the whole thing needs to be redesigned.
