### PR TITLE
Allow top and bottom placement of the sidebar in addition to left and right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 * [#350][gh-350] Add `org-roam-db-location`
 * [#359][gh-359] Add `org-roam-verbose`
+* [#380][gh-380] Allow `org-roam-buffer-position` to also be `top` or `bottom`
 
 ## 1.0.0 (23-03-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -702,14 +702,12 @@ Valid states are 'visible, 'exists and 'none."
         (display-buffer-in-side-window
          `((side . ,org-roam-buffer-position)))
         (select-window))
-    (progn
-      (if (or (eq org-roam-buffer-position 'left)
-              (eq org-roam-buffer-position 'right))
-          (org-roam--set-width
-           (round (* (frame-width) org-roam-buffer-width)))
-          (org-roam--set-height
-           (round (* (frame-height) org-roam-buffer-height))))
-      (select-window window))))
+    (pcase org-roam-buffer-position
+      ('right  (org-roam--set-width  (round (* (frame-width)  org-roam-buffer-width))))
+      ('left   (org-roam--set-width  (round (* (frame-width)  org-roam-buffer-width))))
+      ('top    (org-roam--set-height (round (* (frame-height) org-roam-buffer-height))))
+      ('bottom (org-roam--set-height (round (* (frame-height) org-roam-buffer-height)))))
+    (select-window window)))
 
 (defun org-roam ()
   "Pops up the window `org-roam-buffer' accordingly."

--- a/org-roam.el
+++ b/org-roam.el
@@ -73,9 +73,13 @@ All Org files, at any level of nesting, is considered part of the Org-roam."
   "Position of `org-roam' buffer.
 Valid values are
  * left,
- * right."
+ * right,
+ * top,
+ * bottom."
   :type '(choice (const left)
-                 (const right))
+                 (const right)
+                 (const top)
+                 (const bottom))
   :group 'org-roam)
 
 (defcustom org-roam-link-title-format "%s"
@@ -86,7 +90,15 @@ Formatter may be a function that takes title as its only argument."
           (function :tag "Custom function"))
   :group 'org-roam)
 
-(defcustom org-roam-buffer-width 0.33 "Width of `org-roam' buffer."
+(defcustom org-roam-buffer-width 0.33
+  "Width of `org-roam' buffer.
+Has an effect if and only if `org-roam-buffer-position' is `left' or `right'."
+  :type 'number
+  :group 'org-roam)
+
+(defcustom org-roam-buffer-height 0.27
+  "Height of `org-roam' buffer.
+Has an effect if and only if `org-roam-buffer-position' is `top' or `bottom'."
   :type 'number
   :group 'org-roam)
 
@@ -672,6 +684,17 @@ Valid states are 'visible, 'exists and 'none."
        ((< (window-width) w)
         (enlarge-window-horizontally (- w (window-width))))))))
 
+(defun org-roam--set-height (height)
+  "Set the height of `org-roam-buffer' to `HEIGHT'."
+  (unless (one-window-p)
+    (let ((window-size-fixed)
+          (h (max height window-min-height)))
+      (cond
+       ((> (window-height) h)
+        (shrink-window  (- (window-height) h)))
+       ((< (window-height) h)
+        (enlarge-window (- h (window-height))))))))
+
 (defun org-roam--setup-buffer ()
   "Setup the `org-roam' buffer at the `org-roam-buffer-position'."
   (let ((window (get-buffer-window)))
@@ -679,10 +702,14 @@ Valid states are 'visible, 'exists and 'none."
         (display-buffer-in-side-window
          `((side . ,org-roam-buffer-position)))
         (select-window))
-    (org-roam--set-width
-     (round (* (frame-width)
-               org-roam-buffer-width)))
-    (select-window window)))
+    (progn
+      (if (or (eq org-roam-buffer-position 'left)
+              (eq org-roam-buffer-position 'right))
+          (org-roam--set-width
+           (round (* (frame-width) org-roam-buffer-width)))
+          (org-roam--set-height
+           (round (* (frame-height) org-roam-buffer-height))))
+      (select-window window))))
 
 (defun org-roam ()
   "Pops up the window `org-roam-buffer' accordingly."


### PR DESCRIPTION
###### Motivation for this change
I like to have two files opened in my emacs side by side. Having a sidebar on the left or on the right messes that up, because I don't have enough horizontal space for 3 windows. So I wanted to be able to open it on the bottom instead.

##### Description of changed code
Since there already was code that opened the sidebar on the side, it was trivial to modify to do it on top or on the bottom. I have manually tested that it works.

##### New and modified `customize-group org-roam` variables
* Added `org-roam-buffer height`
* `org-roam-buffer-position` can now be either `top`, or `bottom`, or `left`, or `right`