### PR TITLE
(feat): Add org-roam-graph-node-extra-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 1.0.1 (TBD)
 
+### Breaking Changes
+* [#385][gh-385] Deprecate `org-roam-graph-node-shape` in favour of `org-roam-graph-node-extra-config`.
+
 ### New Features
 * [#350][gh-350] Add `org-roam-db-location`
 * [#359][gh-359] Add `org-roam-verbose`
 * [#380][gh-380] Allow `org-roam-buffer-position` to also be `top` or `bottom`
+* [#385][gh-385] Add `org-roam-graph-node-extra-config` to configure Graphviz nodes
 
 ## 1.0.0 (23-03-2020)
 
@@ -157,6 +161,9 @@ Mostly a documentation/cleanup release.
 [gh-296]: https://github.com/jethrokuan/org-roam/pull/296
 [gh-350]: https://github.com/jethrokuan/org-roam/pull/350
 [gh-359]: https://github.com/jethrokuan/org-roam/pull/359
+[gh-380]: https://github.com/jethrokuan/org-roam/pull/380
+[gh-385]: https://github.com/jethrokuan/org-roam/pull/385
+
 
  # Local Variables:
  # eval: (auto-fill-mode -1)


### PR DESCRIPTION
###### Motivation for this change

Fixes #382 .

`org-roam-graph-node-extra-config` is an alist containing additional node configuration options, as per
https://graphviz.gitlab.io/_pages/doc/info/attrs.html

This also deprecates org-roam-graph-node-shape, which is a special case
of the node options.
