### PR TITLE
(docs): org-roam-db-build-cache

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -31,7 +31,7 @@ what `.dir-locals.el` may contain:
 ```
 
 All files within that directory will be treated as their own separate
-set of Org-roam files. Remember to run `org-roam-build-cache` from a
+set of Org-roam files. Remember to run `org-roam-db-build-cache` from a
 file within that directory, at least once.
 
 ## Org-roam Buffer

--- a/doc/tour.md
+++ b/doc/tour.md
@@ -20,7 +20,7 @@ The cache is a sqlite database named `org-roam.db`, which resides at
 the root of the `org-roam-directory`. Activating `org-roam-mode`
 builds the cache, which may take a while the first time, but is
 generally instantaneous in subsequent runs. To build the cache
-manually again, run `M-x org-roam-build-cache`.
+manually again, run `M-x org-roam-db-build-cache`.
 
 ## Finding a Note
 


### PR DESCRIPTION
Remove references to obsolete variable.
org-roam-build-cache -> org-roam-db-build-cache
See: #394 