### PR TITLE
(internal): Move aliases to org-roam-compat.el

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -238,8 +238,6 @@ the file if the original value of :no-save is not t and
                                      (push (cons key v) org-roam-capture--info)
                                      v))) nil)))
 
-(defalias 'org-roam--capture-get-point 'org-roam-capture--get-point)
-(make-obsolete 'org-roam--capture-get-point 'org-roam-capture--get-point "2020/03/29")
 (defun org-roam-capture--get-point ()
   "Return exact point to file for org-capture-template.
 The file to use is dependent on the context:

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -1,0 +1,61 @@
+;;; org-roam-compat.el --- Compatibility Code -*- coding: utf-8; lexical-binding: t -*-
+
+;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
+
+;; Author: Jethro Kuan <jethrokuan95@gmail.com>
+;; URL: https://github.com/jethrokuan/org-roam
+;; Keywords: org-mode, roam, convenience
+;; Version: 1.0.0-rc1
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; This file contains code needed for backward compatibility with older Emacsen
+;; and previous versions of org-roam.
+;;
+;;; Code:
+;;;; Library Requires
+
+;;; Obsolete aliases (remove after next major release)
+;;;; Functions
+(define-obsolete-function-alias 'org-roam--capture-get-point 'org-roam-capture--get-point
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-build-cache 'org-roam-db-build-cache
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-sql         'org-roam-db-query
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--get-db     'org-roam-db--get
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--db-clear   'org-roam-db--clear
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-show-graph  'org-roam-graph-show
+  "org-roam 1.0.0")
+
+;;;; Variables
+(define-obsolete-variable-alias 'org-roam-graphviz-extra-options
+  'org-roam-graph-extra-config "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam-grapher-extra-options
+  'org-roam-graph-extra-config "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam--db-connection
+  'org-roam-db--connection "org-roam 1.0.0")
+
+(provide 'org-roam-compat)
+
+;;; org-roam-compat.el ends here

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -60,21 +60,15 @@ when used with multiple Org-roam instances."
     (emacsql-sqlite-ensure-binary)
     t))
 
-(defvaralias 'org-roam--db-connection 'org-roam-db--connection)
-(make-obsolete-variable 'org-roam--db-connection 'org-roam-db--connection "2020/03/28")
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")
 
-
 ;;;; Core Functions
-(defalias 'org-roam--get-db 'org-roam-db--get)
-(make-obsolete 'org-roam--get-db 'org-roam-db--get "2020/03/28")
 (defun org-roam-db--get ()
   "Return the sqlite db file."
   (interactive "P")
   (or org-roam-db-location
       (expand-file-name "org-roam.db" org-roam-directory)))
-
 
 (defun org-roam-db--get-connection ()
   "Return the database connection, if any."
@@ -112,8 +106,6 @@ Performs a database upgrade when required."
   (org-roam-db--get-connection))
 
 ;;;; Entrypoint: (org-roam-db-query)
-(defalias 'org-roam-sql 'org-roam-db-query)
-(make-obsolete 'org-roam-sql 'org-roam-db-query "2020/03/28")
 (defun org-roam-db-query (sql &rest args)
   "Run SQL query on Org-roam database with ARGS.
 SQL can be either the emacsql vector representation, or a string."
@@ -188,8 +180,6 @@ the current `org-roam-directory'."
     (error "[Org-roam] your cache isn't built yet! Please run org-roam-db-build-cache")))
 
 ;;;;; Clearing
-(defalias 'org-roam--db-clear 'org-roam-db--clear)
-(make-obsolete 'org-roam--db-clear 'org-roam-db--clear "2020/03/28")
 (defun org-roam-db--clear ()
   "Clears all entries in the caches."
   (interactive)
@@ -313,8 +303,6 @@ If the file does not have any connections, nil is returned."
         (org-roam--maybe-update-buffer :redisplay t)))))
 
 ;;;;; org-roam-db-build-cache
-(defalias 'org-roam-build-cache 'org-roam-db-build-cache)
-(make-obsolete 'org-roam-build-cache 'org-roam-db-build-cache "2020/03/28")
 (defun org-roam-db-build-cache ()
   "Build the cache for `org-roam-directory'."
   (interactive)

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -53,10 +53,6 @@
   :type 'string
   :group 'org-roam)
 
-(defvaralias 'org-roam-graphviz-extra-options 'org-roam-graph-extra-config)
-(defvaralias 'org-roam-grapher-extra-options  'org-roam-graph-extra-config)
-(make-obsolete-variable 'org-roam-graphviz-extra-options 'org-roam-graph-extra-config "2020/03/31")
-(make-obsolete-variable 'org-roam-grapher-extra-options  'org-roam-graph-extra-config "2020/03/31")
 (defcustom org-roam-graph-extra-config nil
   "Extra options passed to graphviz.
 Example:
@@ -168,8 +164,6 @@ into a digraph."
       (insert "}")
       (buffer-string))))
 
-(defalias 'org-roam-show-graph 'org-roam-graph-show)
-(make-obsolete 'org-roam-show-graph 'org-roam-graph-show "2020/03/28")
 (defun org-roam-graph-show (&optional prefix node-query)
   "Generate and displays the Org-roam graph using `org-roam-graph-viewer'.
 If PREFIX, then the graph is generated but the viewer is not invoked."

--- a/org-roam.el
+++ b/org-roam.el
@@ -43,6 +43,7 @@
 (require 'f)
 (require 'cl-lib)
 ;;;; org-roam features
+(require 'org-roam-compat)
 (require 'org-roam-macs)
 (require 'org-roam-db)
 (require 'org-roam-capture)


### PR DESCRIPTION
Same strategy Org uses. Consolidates backward compatibility into a
single location.