### PR TITLE
(bugfix): Use predicate to check for a `org-roam-capture` process

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -364,16 +364,16 @@ If PREFIX, downcase the title before insertion."
           (when region ;; Remove previously selected text.
             (delete-region (car region) (cdr region)))
           (insert (org-roam--format-link target-file-path link-description)))
-      (if org-roam-capture--in-process
-          (user-error "Nested Org-roam capture processes not supported")
-        (let ((org-roam-capture--info (list (cons 'title title)
-                                            (cons 'slug (org-roam--title-to-slug title))))
-              (org-roam-capture--context 'title))
-          (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
-          (setq org-roam-capture-additional-template-props (list :region region
-                                                                 :link-description link-description
-                                                                 :capture-fn 'org-roam-insert))
-          (org-roam--capture))))))
+      (when (org-roam-capture--in-process-p)
+	(user-error "Nested Org-roam capture processes not supported"))
+      (let ((org-roam-capture--info (list (cons 'title title)
+					  (cons 'slug (org-roam--title-to-slug title))))
+	    (org-roam-capture--context 'title))
+	(add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
+	(setq org-roam-capture-additional-template-props (list :region region
+							       :link-description link-description
+							       :capture-fn 'org-roam-insert))
+	(org-roam--capture)))))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
@@ -400,7 +400,7 @@ INITIAL-PROMPT is the initial title prompt."
          (file-path (cdr (assoc title completions))))
     (if file-path
         (find-file file-path)
-      (if org-roam-capture--in-process
+      (if (org-roam-capture--in-process-p)
           (user-error "Org-roam capture in process")
         (let ((org-roam-capture--info (list (cons 'title title)
                                             (cons 'slug (org-roam--title-to-slug title))))


### PR DESCRIPTION
Instead of using a global variable to check for a existing capture,
leverage the :org-roam plist property of the buffer-local variable
`org-roam-capture-current-plist`.

This prevents a lockout if the capture buffer is killed.

###### Motivation for this change
When killing the capture buffer instead of using <kbd>C-c C-k</kbd> I can't start new capture processes:
```
user-error: Nested Org-roam capture processes not supported
```