### PR TITLE
(fix): Detect all org-ref cite types

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -254,7 +254,9 @@ it as FILE-PATH."
                (link-type (cond ((and (string= type "file")
                                       (org-roam--org-file-p path))
                                  "roam")
-                                ((string= type "cite")
+                                ((and
+                                  (require 'org-ref nil t)
+                                  (-contains? org-ref-cite-types type))
                                  "cite")
                                 (t nil))))
           (when link-type


### PR DESCRIPTION
###### Motivation for this change
Adds support for all org-ref recognized cite links