### PR TITLE
Add customization to set no-delete-other-windows

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -83,6 +83,12 @@ Has an effect if and only if `org-roam-buffer-position' is `top' or `bottom'."
   :type 'hook
   :group 'org-roam)
 
+(defcustom org-roam-buffer-no-delete-other-windows nil
+  "The `no-delete-other-windows' parameter of the `org-roam-buffer' window.
+When non-nil, the window will not be closed when deleting other windows."
+  :type 'boolean
+  :group 'org-roam)
+
 (defalias               'org-roam--current-buffer 'org-roam-buffer--current)
 (make-obsolete-variable 'org-roam--current-buffer 'org-roam-buffer--current "2020/04/06")
 (defvar org-roam-buffer--current nil

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -244,7 +244,8 @@ Valid states are 'visible, 'exists and 'none."
            'right)))
     (-> (get-buffer-create org-roam-buffer)
         (display-buffer-in-side-window
-         `((side . ,position)))
+         `((side . ,position)
+           (window-parameters . ((no-delete-other-windows . ,org-roam-buffer-no-delete-other-windows)))))
         (select-window))
     (pcase position
       ((or 'right 'left)

--- a/org-roam.el
+++ b/org-roam.el
@@ -87,6 +87,12 @@ Formatter may be a function that takes title as its only argument."
   :type 'boolean
   :group 'org-roam)
 
+(defcustom org-roam-buffer-no-delete-other-windows nil
+  "The `no-delete-other-windows' parameter of the `org-roam' window.
+When non-nil, the window will not be closed when deleting other windows."
+  :type 'boolean
+  :group 'org-roam)
+
 ;;;; Dynamic variables
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")

--- a/org-roam.el
+++ b/org-roam.el
@@ -87,12 +87,6 @@ Formatter may be a function that takes title as its only argument."
   :type 'boolean
   :group 'org-roam)
 
-(defcustom org-roam-buffer-no-delete-other-windows nil
-  "The `no-delete-other-windows' parameter of the `org-roam' window.
-When non-nil, the window will not be closed when deleting other windows."
-  :type 'boolean
-  :group 'org-roam)
-
 ;;;; Dynamic variables
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")


### PR DESCRIPTION
While navigating links and back-links I'll end up with several buffers
open due to auto-splitting. When I `delete-other-windows` the org-roam
window will also close. With this option set to `t` it will keep the
org-roam window around even when closing other windows.