### PR TITLE
(feat) Add org-roam-find-directory

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -379,6 +379,12 @@ INITIAL-PROMPT is the initial title prompt."
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
           (org-roam--capture))))))
 
+;;;; org-roam-find-directory
+(defun org-roam-find-directory ()
+  "Find and open `org-roam-directory'."
+  (interactive)
+  (find-file org-roam-directory))
+
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()
   "Return a list of cons pairs for titles to absolute path of Org-roam files."


### PR DESCRIPTION
Hello,

This is a very small PR to implement `org-roam-find-directory`.  I was surprised to see that it didn't exist.  I often find myself going to the directory, both for managing names and testing stuff for development.

HTH.