### PR TITLE
(bugfix): Explicitly load subr-x library

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -31,6 +31,7 @@
 ;;
 ;;; Code:
 ;;;; Library Requires
+(require 'subr-x)
 (require 'emacsql)
 (require 'emacsql-sqlite)
 (require 'org-roam-macs)


### PR DESCRIPTION
Ensure the `when-let` macro definitions is available during
compile-time.

###### Motivation for this change
I encountered this issue today:

```
Debugger entered--Lisp error: (void-function links)
  links((["/home/juergen/shared/org/roam/2020-04-10.org"   org-roam-db-build-cache()
....
  org-roam-mode()
  run-hooks(after-init-hook delayed-warnings-hook)
  command-line()
  normal-top-level()
```
Because the macro `when-let` macro was not available at compile time:
```
org-roam-db.el:325:32:Warning: reference to free variable ‘links’
org-roam-db.el:329:44:Warning: reference to free variable ‘ref’
```

Note: The problem might not occur in all environments because the `subr-x` macro definition might been preloaded by other packages.