### PR TITLE
Split building and showing of the graph into two functions

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -164,11 +164,10 @@ into a digraph."
       (insert "}")
       (buffer-string))))
 
-(defun org-roam-graph-show (&optional prefix node-query)
-  "Generate and displays the Org-roam graph using `org-roam-graph-viewer'.
-If PREFIX, then the graph is generated but the viewer is not invoked."
-  (interactive "P")
-  (declare (indent 0))
+(defun org-roam-graph-build (&optional node-query)
+  "Generate a graph showing the relations between nodes in NODE-QUERY.
+For building and showing the graph in a single step see `org-roam-graph-show'."
+  (interactive)
   (unless org-roam-graph-executable
     (user-error "Can't find %s executable.  Please check if it is in your path"
                 org-roam-graph-executable))
@@ -181,15 +180,25 @@ If PREFIX, then the graph is generated but the viewer is not invoked."
     (with-temp-file temp-dot
       (insert graph))
     (call-process org-roam-graph-executable nil 0 nil temp-dot "-Tsvg" "-o" temp-graph)
-    (unless prefix
-      (if (and org-roam-graph-viewer (executable-find org-roam-graph-viewer))
-	        (call-process org-roam-graph-viewer nil 0 nil temp-graph)
-        (view-file temp-graph)))))
+    temp-graph))
 
-(defun org-roam-graph-show-connected-component (&optional max-distance no-display)
-  "Like `org-roam-graph-show', but only show nodes connected to the current entry.
-If MAX-DISTANCE is non-nil, only nodes within the given number of steps are shown.
-If NO-DISPLAY is non-nil, the graph is generated but the viewer is not invoked."
+(defun org-roam-graph--open (file)
+  "Open FILE using `org-roam-graph-viewer', with `view-file' as a fallback."
+  (if (and org-roam-graph-viewer (executable-find org-roam-graph-viewer))
+      (call-process org-roam-graph-viewer nil 0 nil file)
+    (view-file temp-graph)))
+
+(defun org-roam-graph-show (&optional node-query)
+  "Generate and display a graph showing the relations between nodes in NODE-QUERY.
+The graph is generated using `org-roam-graph-build' and subsequently displayed
+using `org-roam-graph-viewer', if it refers to a valid executable, or using
+`view-file' otherwise."
+  (interactive)
+  (org-roam-graph--open (org-roam-graph-build node-query)))
+
+(defun org-roam-graph-build-connected-component (&optional max-distance)
+  "Like `org-roam-graph-build', but only include nodes connected to the current entry.
+If MAX-DISTANCE is non-nil, only nodes within the given number of steps are shown."
   (interactive "P")
   (unless (org-roam--org-roam-file-p)
     (user-error "Not in an Org-roam file"))
@@ -201,7 +210,13 @@ If NO-DISPLAY is non-nil, the graph is generated but the viewer is not invoked."
          (query `[:select [file titles]
                   :from titles
                   :where (in file [,@files])]))
-    (org-roam-graph-show no-display query)))
+    (org-roam-graph-build query)))
+
+(defun org-roam-graph-show-connected-component (&optional max-distance)
+  "Like `org-roam-graph-show', but only include nodes connected to the current entry.
+If MAX-DISTANCE is non-nil, only nodes within the given number of steps are shown."
+  (interactive "P")
+  (org-roam-graph--open (org-roam-graph-build-connected-component max-distance)))
 
 (provide 'org-roam-graph)
 


### PR DESCRIPTION
###### Motivation for this change

As discussed in #418 it's useful to free up the prefix of `org-graph-show-*` for other uses. To still allow only building the graph without displaying it, this part is split into a separate function in this PR.