### PR TITLE
(feat) cond display relative subdir in title for selection

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -324,7 +324,7 @@ If the file does not have any connections, nil is returned."
                   (cons (vector file contents-hash time) all-files))
             (when-let (links (org-roam--extract-links file))
               (setq all-links (append links all-links)))
-            (let ((titles (org-roam--extract-titles)))
+            (let ((titles (org-roam--extract-titles file)))
               (setq all-titles (cons (vector file titles) all-titles)))
             (when-let ((ref (org-roam--extract-ref)))
               (setq all-refs (cons (vector ref file) all-refs))))


### PR DESCRIPTION
A title can now be constructed as `subdir/file-title` where `subdir` is the sub-directory relative from `org-roam-directory`.

When `org-roam-title-include-subdirs` is non-nil, `org-roam--extract-titles` now outputs titles in this format.

###### Motivation for this change

Hello,

This PR is a result of the discussions in #423.  In it, we discussed the possibility of having files with the same `#:TITLE:` (or alias) across different sub-directories.  The problem is that, currently, having both `lit/ahrens2017.org` with `#:TITLE: ahrens2017` and `refs/ahrens2017.org` with `#:TITLE: ahrens2017` would cause problems with `org-roam-find-file`, since the parser would generate a list with `ahrens2017` appearing two times.

I've created a switch to enable this option, which is disabled by default.

Please let me know if there's anything I've missed.

HTH.