### PR TITLE
(bugfix): Explicitly load subr-x library

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -30,6 +30,7 @@
 ;; This library provides the org-roam-buffer functionality for org-roam
 ;;; Code:
 ;;;; Library Requires
+(require 'subr-x)
 (require 'cl-lib)
 (require 'dash)
 (require 's)

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -30,7 +30,7 @@
 ;; This library provides the org-roam-buffer functionality for org-roam
 ;;; Code:
 ;;;; Library Requires
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 (require 'cl-lib)
 (require 'dash)
 (require 's)


### PR DESCRIPTION
Ensure the `if-let*` macro definitions is available during
compile-time.

###### Motivation for this change
Same as #425 

This time `if-let*` is missing:

```
In org-roam-buffer--insert-citelinks:
org-roam-buffer.el:104:8:Warning: ‘(roam-key (with-temp-buffer
    (insert-buffer-substring org-roam-buffer--current)
    (org-roam--extract-ref)))’ is a malformed function
org-roam-buffer.el:109:76:Warning: reference to free variable ‘roam-key’
org-roam-buffer.el:113:33:Warning: reference to free variable ‘key-backlinks’
org-roam-buffer.el:117:22:Warning: reference to free variable
    ‘grouped-backlinks’

In org-roam-buffer--insert-backlinks:
org-roam-buffer.el:131:8:Warning: ‘(file-path (buffer-file-name
    org-roam-buffer--current))’ is a malformed function
org-roam-buffer.el:134:49:Warning: reference to free variable ‘file-path’
org-roam-buffer.el:138:33:Warning: reference to free variable ‘backlinks’
org-roam-buffer.el:142:22:Warning: reference to free variable
    ‘grouped-backlinks’
```