### PR TITLE
(tiny-fix) reuse variable defined in let-form

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -400,7 +400,7 @@ INFO is an alist containing additional information."
   (let* ((completions (org-roam--get-ref-path-completions))
          (ref (or (cdr (assoc 'ref info))
                   (org-roam-completion--completing-read "Ref: "
-                                                        (org-roam--get-ref-path-completions)
+                                                        completions
                                                         :require-match t))))
     (find-file (cdr (assoc ref completions)))))
 


### PR DESCRIPTION
Spotted a little area where we could reuse a variable we computed in a wrapping `let`-form.