### PR TITLE
(refactor): org-roam-db.el eval-when-compile subr-x

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -31,7 +31,7 @@
 ;;
 ;;; Code:
 ;;;; Library Requires
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 (require 'emacsql)
 (require 'emacsql-sqlite)
 (require 'org-roam-macs)


### PR DESCRIPTION
Prevents unnecessary evaluation when compiled .elc is loaded.
From the commentary of subr-x.el:
;; NB If you want to use this library, it's almost always correct to use:
;; (eval-when-compile (require 'subr-x))

See: #429
