### PR TITLE
(refactor): Move obsolete vars/functions to org-roam-compat

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -89,8 +89,6 @@ When non-nil, the window will not be closed when deleting other windows."
   :type 'boolean
   :group 'org-roam)
 
-(defalias               'org-roam--current-buffer 'org-roam-buffer--current)
-(make-obsolete-variable 'org-roam--current-buffer 'org-roam-buffer--current "2020/04/06")
 (defvar org-roam-buffer--current nil
   "Currently displayed file in `org-roam' buffer.")
 
@@ -153,8 +151,6 @@ When non-nil, the window will not be closed when deleting other windows."
                 (insert "\n\n"))))))
     (insert "\n\n* No backlinks!")))
 
-(defalias      'org-roam-update 'org-roam-buffer-update)
-(make-obsolete 'org-roam-update 'org-roam-buffer-update "2020/04/06")
 (defun org-roam-buffer-update ()
   "Update the `org-roam-buffer'."
   (org-roam-db--ensure-built)
@@ -181,8 +177,6 @@ When non-nil, the window will not be closed when deleting other windows."
         (run-hooks 'org-roam-buffer-prepare-hook)
         (read-only-mode 1)))))
 
-(defalias      'org-roam--maybe-update-buffer 'org-roam-buffer--update-maybe)
-(make-obsolete 'org-roam--maybe-update-buffer 'org-roam-buffer--update-maybe "2020/04/06")
 (cl-defun org-roam-buffer--update-maybe (&key redisplay)
   "Reconstructs `org-roam-buffer'.
 This needs to be quick or infrequent, because this is run at
@@ -197,8 +191,6 @@ This needs to be quick or infrequent, because this is run at
       (org-roam-buffer-update))))
 
 ;;;; Toggling the org-roam buffer
-(defalias      'org-roam--current-visibility 'org-roam-buffer--visibility)
-(make-obsolete 'org-roam--current-visibility 'org-roam-buffer--visibility "2020/04/06")
 (define-inline org-roam-buffer--visibility ()
   "Return whether the current visibility state of the org-roam buffer.
 Valid states are 'visible, 'exists and 'none."
@@ -209,8 +201,6 @@ Valid states are 'visible, 'exists and 'none."
     ((get-buffer org-roam-buffer) 'exists)
     (t 'none))))
 
-(defalias      'org-roam--set-width 'org-roam-buffer--set-width)
-(make-obsolete 'org-roam--set-width 'org-roam-buffer--set-width "2020/04/06")
 (defun org-roam-buffer--set-width (width)
   "Set the width of `org-roam-buffer' to `WIDTH'."
   (unless (one-window-p)
@@ -222,8 +212,6 @@ Valid states are 'visible, 'exists and 'none."
        ((< (window-width) w)
         (enlarge-window-horizontally (- w (window-width))))))))
 
-(defalias      'org-roam--set-height 'org-roam-buffer--set-height)
-(make-obsolete 'org-roam--set-height 'org-roam-buffer--set-height "2020/04/06")
 (defun org-roam-buffer--set-height (height)
   "Set the height of `org-roam-buffer' to `HEIGHT'."
   (unless (one-window-p)
@@ -235,8 +223,6 @@ Valid states are 'visible, 'exists and 'none."
        ((< (window-height) h)
         (enlarge-window (- h (window-height))))))))
 
-(defalias      'org-roam--set-up-buffer 'org-roam-buffer--get-create)
-(make-obsolete 'org-roam--set-up-buffer 'org-roam-buffer--get-create "2020/04/06")
 (defun org-roam-buffer--get-create ()
   "Set up the `org-roam' buffer at `org-roam-buffer-position'."
   (let ((window (get-buffer-window))

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -47,6 +47,18 @@
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam-show-graph  'org-roam-graph-show
   "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--maybe-update-buffer
+  'org-roam-buffer--update-maybe "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--current-visibility
+  'org-roam-buffer--visibility "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-update         'org-roam-buffer-update
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--set-width     'org-roam-buffer--set-width
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--set-height    'org-roam-buffer--set-height
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam--set-up-buffer 'org-roam-buffer--get-create
+  "org-roam 1.0.0")
 
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
@@ -55,6 +67,8 @@
   'org-roam-graph-extra-config "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam--db-connection
   'org-roam-db--connection "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam--current-buffer
+  'org-roam-buffer--current "org-roam 1.0.0")
 
 (provide 'org-roam-compat)
 


### PR DESCRIPTION
###### Motivation for this change
Sorry. Missed these earlier.