### PR TITLE
(feat): add org-roam-graph-edge-extra-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#374][gh-374] Add support for `org-ref` `cite:` links
 * [#380][gh-380] Allow `org-roam-buffer-position` to also be `top` or `bottom`
 * [#385][gh-385] Add `org-roam-graph-node-extra-config` to configure Graphviz nodes
+* [#435][gh-435] Add `org-roam-graph-edge-extra-config` to configure Graphviz edges
 
 ## 1.0.0 (23-03-2020)
 


### PR DESCRIPTION
I want to change direction of edges, so a note points to notes it
references.

Introduce `org-roam-graph-edge-extra-config` in the spirit of
`org-roam-graph-node-extra-config`, so I can add `dir=back`.

Also, refactor so default node/edge properties are specified once.