### PR TITLE
(fix) typo in doc, titles -> refs

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -387,7 +387,7 @@ INITIAL-PROMPT is the initial title prompt."
 
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()
-  "Return a list of cons pairs for titles to absolute path of Org-roam files."
+  "Return a list of cons pairs for refs to absolute path of Org-roam files."
   (let ((rows (org-roam-db-query [:select [ref file] :from refs])))
     (mapcar (lambda (row)
               (cons (car row)


### PR DESCRIPTION
Small typo in the doc.