### PR TITLE
Add edges in graph relating to org-ref cite links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#380][gh-380] Allow `org-roam-buffer-position` to also be `top` or `bottom`
 * [#385][gh-385] Add `org-roam-graph-node-extra-config` to configure Graphviz nodes
 * [#435][gh-435] Add `org-roam-graph-edge-extra-config` to configure Graphviz edges
+* [#439][gh-439] Add support for `org-ref` citations to display as edges in graph. Add `org-roam-graph-edge-cites-extra-config` to configure these edges
 
 ## 1.0.0 (23-03-2020)
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -253,8 +253,14 @@ This is equivalent to removing the node from the graph."
 If the file does not have any connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS
-                     (SELECT \"from\", \"to\" FROM links UNION
-                      SELECT \"to\", \"from\" FROM links),
+                     (WITH roamlinks AS (SELECT * FROM links WHERE \"type\" = '\"roam\"'),
+                           citelinks AS (SELECT * FROM links
+                                                  JOIN refs ON links.\"to\" = refs.\"ref\"
+                                                            AND links.\"type\" = '\"cite\"')
+                      SELECT \"from\", \"to\" FROM roamlinks UNION
+                      SELECT \"to\", \"from\" FROM roamlinks UNION
+                      SELECT \"file\", \"from\" FROM citelinks UNION
+                      SELECT \"from\", \"file\" FROM citelinks),
                    connected_component(file) AS
                      (SELECT link FROM links_of WHERE file = $s1
                       UNION
@@ -268,8 +274,14 @@ If the file does not have any connections, nil is returned."
 including the file itself.  If the file does not have any connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS
-                     (SELECT \"from\", \"to\" FROM links UNION
-                      SELECT \"to\", \"from\" FROM links),
+                     (WITH roamlinks AS (SELECT * FROM links WHERE \"type\" = '\"roam\"'),
+                           citelinks AS (SELECT * FROM links
+                                                  JOIN refs ON links.\"to\" = refs.\"ref\"
+                                                            AND links.\"type\" = '\"cite\"')
+                      SELECT \"from\", \"to\" FROM roamlinks UNION
+                      SELECT \"to\", \"from\" FROM roamlinks UNION
+                      SELECT \"file\", \"from\" FROM citelinks UNION
+                      SELECT \"from\", \"file\" FROM citelinks),
                    -- Links are traversed in a breadth-first search.  In order to calculate the
                    -- distance of nodes and to avoid following cyclic links, the visited nodes
                    -- are tracked in 'trace'.

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -142,8 +142,8 @@ into a digraph."
            (edges-cites-query
             `[:with selected :as [:select [file] :from ,node-query]
               :select :distinct [file from]
-              :from links :inner :join refs :on (= links:to refs:ref)
-              :where (and (in file selected) (in from selected) (= type "cite"))])
+              :from links :inner :join refs :on (and (= links:to refs:ref) (= links:type "cite"))
+              :where (and (in file selected) (in from selected))])
            (edges (append (org-roam-db-query edges-query) (org-roam-db-query edges-cites-query))))
       (insert "digraph \"org-roam\" {\n")
 

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -139,7 +139,12 @@ into a digraph."
             `[:with selected :as [:select [file] :from ,node-query]
               :select :distinct [to from] :from links
               :where (and (in to selected) (in from selected))])
-           (edges (org-roam-db-query edges-query)))
+           (edges-cites-query
+            `[:with selected :as [:select [file] :from ,node-query]
+              :select :distinct [file from]
+              :from links :inner :join refs :on (= links:to refs:ref)
+              :where (and (in file selected) (in from selected) (= type "cite"))])
+           (edges (append (org-roam-db-query edges-query) (org-roam-db-query edges-cites-query))))
       (insert "digraph \"org-roam\" {\n")
 
       (dolist (option org-roam-graph-extra-config)

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -74,6 +74,13 @@ Example:
   :type '(alist)
   :group 'org-roam)
 
+(defcustom org-roam-graph-edge-cites-extra-config '(("color" . "red"))
+  "Extra options for graphviz edges for citation links.
+Example:
+ '((\"dir\" . \"back\"))"
+  :type '(alist)
+  :group 'org-roam)
+
 (defcustom org-roam-graph-max-title-length 100
   "Maximum length of titles in graph nodes."
   :type 'number
@@ -144,7 +151,8 @@ into a digraph."
               :select :distinct [file from]
               :from links :inner :join refs :on (and (= links:to refs:ref) (= links:type "cite"))
               :where (and (in file selected) (in from selected))])
-           (edges (append (org-roam-db-query edges-query) (org-roam-db-query edges-cites-query))))
+           (edges (org-roam-db-query edges-query))
+           (edges-cites (org-roam-db-query edges-cites-query)))
       (insert "digraph \"org-roam\" {\n")
 
       (dolist (option org-roam-graph-extra-config)
@@ -181,6 +189,16 @@ into a digraph."
                                   (concat (car n) "=" "\"" (cdr n) "\"")))
                         (s-join ","))))))
       (dolist (edge edges)
+        (insert (format "  \"%s\" -> \"%s\";\n"
+                        (xml-escape-string (car edge))
+                        (xml-escape-string (cadr edge)))))
+
+      (insert (format "  edge [%s];\n"
+                      (->> org-roam-graph-edge-cites-extra-config
+                           (mapcar (lambda (n)
+                                     (concat (car n) "=" (cdr n))))
+                           (s-join ","))))
+      (dolist (edge edges-cites)
         (insert (format "  \"%s\" -> \"%s\";\n"
                         (xml-escape-string (car edge))
                         (xml-escape-string (cadr edge)))))


### PR DESCRIPTION
Now that citations appear as backlinks in the backlinks buffer, it makes sense for them to also show
up in the graph.

I'm quite a novice as SQL, so this query probably could have been merged into the previous, but this
works for now.

###### Motivation for this change
Citation links appear in the backlinks buffer, so they should probably appear in the graph view
