### PR TITLE
Allow multiple ROAM_KEY per file.

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -40,7 +40,7 @@
 (defvar org-roam-backlinks-mode)
 (defvar org-roam-last-window)
 (declare-function org-roam-db--ensure-built   "org-roam-db")
-(declare-function org-roam--extract-ref       "org-roam")
+(declare-function org-roam--extract-refs      "org-roam")
 (declare-function org-roam--get-title-or-slug "org-roam")
 (declare-function org-roam--get-backlinks     "org-roam")
 (declare-function org-roam-backlinks-mode     "org-roam")
@@ -101,10 +101,13 @@ When non-nil, the window will not be closed when deleting other windows."
 
 (defun org-roam-buffer--insert-citelinks ()
   "Insert citation backlinks for the current buffer."
-  (if-let* ((roam-key (with-temp-buffer
+  (if-let* ((roam-keys (with-temp-buffer
                         (insert-buffer-substring org-roam-buffer--current)
-                        (org-roam--extract-ref)))
-            (key-backlinks (org-roam--get-backlinks (s-chop-prefix "cite:" roam-key)))
+                        (org-roam--extract-refs)))
+            (key-backlinks (mapcan (lambda (roam-key)
+                                     (org-roam--get-backlinks
+                                      (s-chop-prefix "cite:" roam-key)))
+                 roam-keys))
             (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
       (progn
         (insert (format "\n\n* %d Cite backlinks\n"

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -40,7 +40,7 @@
 (defvar org-roam-verbose)
 
 (declare-function org-roam--extract-titles      "org-roam")
-(declare-function org-roam--extract-ref         "org-roam")
+(declare-function org-roam--extract-refs        "org-roam")
 (declare-function org-roam--extract-links       "org-roam")
 (declare-function org-roam--list-files          "org-roam")
 (declare-function org-roam-buffer--update-maybe "org-roam-buffer")
@@ -304,8 +304,8 @@ including the file itself.  If the file does not have any connections, nil is re
     (org-roam-db-query [:delete :from refs
                         :where (= file $s1)]
                        file)
-    (when-let ((ref (org-roam--extract-ref)))
-      (org-roam-db--insert-ref file ref))))
+    (when-let ((refs (org-roam--extract-refs)))
+      (mapc (lambda (ref) (org-roam-db--insert-ref file ref)) refs))))
 
 (defun org-roam-db--update-cache-links ()
   "Update the file links of the current buffer in the cache."
@@ -352,7 +352,7 @@ including the file itself.  If the file does not have any connections, nil is re
               (setq all-links (append links all-links)))
             (let ((titles (org-roam--extract-titles)))
               (setq all-titles (cons (vector file titles) all-titles)))
-            (when-let ((ref (org-roam--extract-ref)))
+            (when-let ((ref (org-roam--extract-refs)))
               (setq all-refs (cons (vector ref file) all-refs))))
           (remhash file current-files))))
     (dolist (file (hash-table-keys current-files))

--- a/org-roam.el
+++ b/org-roam.el
@@ -258,9 +258,17 @@ specified via the #+ROAM_ALIAS property."
         (cons title alias-list)
       alias-list)))
 
-(defun org-roam--extract-ref ()
-  "Extract the ref from current buffer."
-  (cdr (assoc "ROAM_KEY" (org-roam--extract-global-props '("ROAM_KEY")))))
+(defun org-roam--extract-refs ()
+  "Extract the refs from current buffer."
+  (let ((buf (org-element-parse-buffer)))
+    (org-element-map buf 'keyword
+      (lambda (kw)
+        (when (string= (org-element-property :key kw) "ROAM_KEY")
+          (org-element-property :value kw)))
+        )
+    )
+ )
+
 ;;;; Title/Path/Slug conversion
 (defun org-roam--path-to-slug (path)
   "Return a slug from PATH."


### PR DESCRIPTION


###### Motivation for this change
Some resourcs are identified by multiple URLs, so it is useful for the
bookmarklet for both of them to refer to the same note.