### PR TITLE
Use MELPA for installing in Spacemacs

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -56,8 +56,7 @@ wraps Org-roam. Paste the following into a new file
 
 ```emacs-lisp
 (defconst org-roam-packages
-  '((org-roam :location
-              (recipe :fetcher github :repo "jethrokuan/org-roam"))))
+  '(org-roam))
 
 (defun org-roam/init-org-roam ()
   (use-package org-roam


### PR DESCRIPTION
###### Motivation for this change

Now that org-roam is out on MELPA, let's suggest that people use it
instead of GitHub to install the package.