### PR TITLE
(docs) Correct database query function

### DIFF
--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -9,7 +9,7 @@ in-built publishing or ox-hugo -- use the following snippet to add a
        (concat acc (format "- [[file:%s][%s]]\n"
                            (file-relative-name (car it) org-roam-directory)
 			                     (org-roam--get-title-or-slug (car it))))
-       "" (org-roam-sql [:select [from] :from links :where (= to $s1) :and (= from $s2)] file "roam"))
+       "" (org-roam-db-query [:select [from] :from links :where (= to $s1)] file))
     ""))
 
 (defun my/org-export-preprocessor (backend)


### PR DESCRIPTION
##### Motivation for this change

`org-roam-sql` is obsolete now. Also changed the syntax that works for the new `org-roam-db-query` function.