### PR TITLE
Add option for exporting backlinks with contents.

### DIFF
--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -28,7 +28,7 @@ This would display only the backlinks and not the contents.
 ```
 
 
-# Backlinks and Contents
+### Backlinks and Contents
 
 This would insert both backlinks and the contents, just like the org-roam buffer. This might be especially useful if you host a web version of your personal knowledgebase and want to browse the files along with the backlinks from mobile devices.
 

--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -2,10 +2,9 @@ While exporting your documents to another format such as HTML -- whether using O
 
 Following are two different configs that might be suitable for different use-cases. Add one of these snippets in your Emacs init file.
 
-
 ### Only Backlinks
 
-This would display only the backlinks and not the contents.
+This will display only the backlinks and not the contents.
 
 ```emacs-lisp
 (defun my/org-roam--backlinks-list (file)
@@ -27,7 +26,6 @@ This would display only the backlinks and not the contents.
 (add-hook 'org-export-before-processing-hook 'my/org-export-preprocessor)
 ```
 
-
 ### Backlinks and Contents
 
 This would insert both backlinks and the contents, just like the org-roam buffer. This might be especially useful if you host a web version of your personal knowledgebase and want to browse the files along with the backlinks from mobile devices.
@@ -48,13 +46,9 @@ This would insert both backlinks and the contents, just like the org-roam buffer
                               (org-roam--get-title-or-slug file-from)))
               (dolist (backlink bls)
                 (pcase-let ((`(,file-from _ ,props) backlink))
-
                   (insert (s-trim (s-replace "\n" " " (plist-get props :content))))
                   (insert "\n\n")))))))
     (buffer-string)))
-
-
-
 
   (defun my/org-export-preprocessor (backend)
     (let ((links (my/org-roam--backlinks-list-with-content (buffer-file-name))))

--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -1,6 +1,11 @@
-To include the backlinks in your Org file export -- whether using Org's
-in-built publishing or ox-hugo -- use the following snippet to add a
-"Backlinks" section at the end of the page:
+While exporting your documents to another format such as HTML -- whether using Org's in-built export or ox-hugo -- you can add a backlinks section which would display the backlinks to the current file. This is done via org-export's preprocessing hooks. See more at [Advanced Export Configuration (The Org Manual)](https://orgmode.org/manual/Advanced-Export-Configuration.html#Advanced-Export-Configuration).
+
+Following are two different configs that might be suitable for different use-cases. Add one of these snippets in your Emacs init file.
+
+
+### Only Backlinks
+
+This would display only the backlinks and not the contents.
 
 ```emacs-lisp
 (defun my/org-roam--backlinks-list (file)
@@ -20,4 +25,48 @@ in-built publishing or ox-hugo -- use the following snippet to add a
       	(insert (concat "\n* Backlinks\n") links)))))
 
 (add-hook 'org-export-before-processing-hook 'my/org-export-preprocessor)
+```
+
+
+# Backlinks and Contents
+
+This would insert both backlinks and the contents, just like the org-roam buffer. This might be especially useful if you host a web version of your personal knowledgebase and want to browse the files along with the backlinks from mobile devices.
+
+```emacs-lisp
+  (defun my/org-roam--backlinks-list-with-content (file)
+    (with-temp-buffer
+      (if-let* ((backlinks (org-roam--get-backlinks file))
+                (grouped-backlinks (--group-by (nth 0 it) backlinks)))
+          (progn
+            (insert (format "\n\n* %d Backlinks\n"
+                            (length backlinks)))
+            (dolist (group grouped-backlinks)
+              (let ((file-from (car group))
+                    (bls (cdr group)))
+                (insert (format "** [[file:%s][%s]]\n"
+                                file-from
+                                (org-roam--get-title-or-slug file-from)))
+                (dolist (backlink bls)
+                  (pcase-let ((`(,file-from _ ,props) backlink))
+                    (insert (propertize
+                             (s-trim (s-replace "\n" " "
+                                                (plist-get props :content)))
+                             'help-echo "mouse-1: visit backlinked note"
+                             'file-from file-from
+                             'file-from-point (plist-get props :point)))
+                    (insert "\n\n"))))))
+        (insert "\n\n* No backlinks!"))
+
+      (buffer-string))
+    )
+
+
+  (defun my/org-export-preprocessor (backend)
+    (let ((links (my/org-roam--backlinks-list-with-content (buffer-file-name))))
+      (unless (string= links "")
+        (save-excursion
+          (goto-char (point-max))
+          (insert (concat "\n* Backlinks\n") links)))))
+
+  (add-hook 'org-export-before-processing-hook 'my/org-export-preprocessor)
 ```

--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -33,26 +33,26 @@ This would display only the backlinks and not the contents.
 This would insert both backlinks and the contents, just like the org-roam buffer. This might be especially useful if you host a web version of your personal knowledgebase and want to browse the files along with the backlinks from mobile devices.
 
 ```emacs-lisp
-  (defun my/org-roam--backlinks-list-with-content (file)
-    (with-temp-buffer
-      (if-let* ((backlinks (org-roam--get-backlinks file))
-                (grouped-backlinks (--group-by (nth 0 it) backlinks)))
-          (progn
-            (insert (format "\n\n* %d Backlinks\n"
-                            (length backlinks)))
-            (dolist (group grouped-backlinks)
-              (let ((file-from (car group))
-                    (bls (cdr group)))
-                (insert (format "** [[file:%s][%s]]\n"
-                                file-from
-                                (org-roam--get-title-or-slug file-from)))
-                (dolist (backlink bls)
-                (insert backlink)
-                  (pcase-let ((`(,file-from _ ,props) backlink))
-                    (insert (s-trim (s-replace "\n" " " (plist-get props :content))))
-                    (insert "\n\n"))
-))))
-      (buffer-string)))
+(defun my/org-roam--backlinks-list-with-content (file)
+  (with-temp-buffer
+    (if-let* ((backlinks (org-roam--get-backlinks file))
+              (grouped-backlinks (--group-by (nth 0 it) backlinks)))
+        (progn
+          (insert (format "\n\n* %d Backlinks\n"
+                          (length backlinks)))
+          (dolist (group grouped-backlinks)
+            (let ((file-from (car group))
+                  (bls (cdr group)))
+              (insert (format "** [[file:%s][%s]]\n"
+                              file-from
+                              (org-roam--get-title-or-slug file-from)))
+              (dolist (backlink bls)
+                (pcase-let ((`(,file-from _ ,props) backlink))
+
+                  (insert (s-trim (s-replace "\n" " " (plist-get props :content))))
+                  (insert "\n\n")))))))
+    (buffer-string)))
+
 
 
 

--- a/doc/org_export.md
+++ b/doc/org_export.md
@@ -47,18 +47,13 @@ This would insert both backlinks and the contents, just like the org-roam buffer
                                 file-from
                                 (org-roam--get-title-or-slug file-from)))
                 (dolist (backlink bls)
+                (insert backlink)
                   (pcase-let ((`(,file-from _ ,props) backlink))
-                    (insert (propertize
-                             (s-trim (s-replace "\n" " "
-                                                (plist-get props :content)))
-                             'help-echo "mouse-1: visit backlinked note"
-                             'file-from file-from
-                             'file-from-point (plist-get props :point)))
-                    (insert "\n\n"))))))
-        (insert "\n\n* No backlinks!"))
+                    (insert (s-trim (s-replace "\n" " " (plist-get props :content))))
+                    (insert "\n\n"))
+))))
+      (buffer-string)))
 
-      (buffer-string))
-    )
 
 
   (defun my/org-export-preprocessor (backend)


### PR DESCRIPTION
###### Motivation for this change

It would be nice to have a complete `org-modes` like functionality in exports. This extra code snippet (slightly modified from [org-roam-buffer-insert-backlinks](https://github.com/jethrokuan/org-roam/blob/772505ba70c073ebc7905c4fcb8b9cc3759c775a/org-roam-buffer.el#L130)) provides that.