### PR TITLE
(bugfix): add workaround for undocumented `file-truename` behavior

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -163,12 +163,12 @@ Like `file-name-extension', but does not strip version number."
 (defun org-roam--org-roam-file-p (&optional file)
   "Return t if FILE is part of Org-roam system, nil otherwise.
 If FILE is not specified, use the current buffer's file-path."
-  (let ((path (or file
+  (if-let ((path (or file
                   (buffer-file-name))))
-    (and path
-         (org-roam--org-file-p path)
-         (f-descendant-of-p (file-truename path)
-                            (file-truename org-roam-directory)))))
+      (save-match-data
+	(org-roam--org-file-p path)
+	(f-descendant-of-p (file-truename path)
+			   (file-truename org-roam-directory)))))
 
 (defun org-roam--list-files (dir)
   "Return all Org-roam files located within DIR, at any nesting level.


### PR DESCRIPTION
This prevents and error being generated when the agenda is displayed.

Fixes #408

###### Motivation for this change
Agenda can't be displayed when using `~` in `org-roam-directory`.

This error was really hard to tackle down because match data is only modified when using tilde (expansion):

```
(progn
;; evals to 0 instead of 1
  (progn
    (string-match "b" "ab")
    (file-truename "~/")
    (match-beginning 0))
```