### PR TITLE
(internal): extract daily notes functionality

### DIFF
--- a/doc/ecosystem.md
+++ b/doc/ecosystem.md
@@ -53,10 +53,9 @@ search engine and indexer.
 
 ## Org-journal
 
-[Org-journal](https://github.com/bastibe/org-journal) is a more
-powerful alternative to the simple function `org-roam-today`. It
-provides better journaling capabilities, and a nice calendar interface
-to see all dated entries.
+[Org-journal](https://github.com/bastibe/org-journal) is a more powerful
+alternative to the simple function `org-roam-dailies-today`. It provides better
+journaling capabilities, and a nice calendar interface to see all dated entries.
 
 ```emacs-lisp
 (use-package org-journal

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -69,14 +69,14 @@ wraps Org-roam. Paste the following into a new file
       (spacemacs/declare-prefix "ar" "org-roam")
       (spacemacs/set-leader-keys
        "arl" 'org-roam
-       "art" 'org-roam-today
+       "art" 'org-roam-dailies-today
        "arf" 'org-roam-find-file
        "arg" 'org-roam-graph-show)
 
       (spacemacs/declare-prefix-for-mode 'org-mode "mr" "org-roam")
       (spacemacs/set-leader-keys-for-major-mode 'org-mode
                                                 "rl" 'org-roam
-                                                "rt" 'org-roam-today
+                                                "rt" 'org-roam-dailies-today
                                                 "rb" 'org-roam-switch-to-buffer
                                                 "rf" 'org-roam-find-file
                                                 "ri" 'org-roam-insert

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -249,8 +249,8 @@ If the search is via title, it is assumed that the file does not
 yet exist, and Org-roam will attempt to create new file.
 
 If the search is via daily notes, 'time will be passed via
-`org-roam-capture--context'. This is used to alter the default
-time in `org-capture-templates'.
+`org-roam-capture--info'. This is used to alter the default time
+in `org-capture-templates'.
 
 If the search is via ref, it is matched against the Org-roam database.
 If there is no file with that ref, a file with that ref is created.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -217,11 +217,10 @@ the file if the original value of :no-save is not t and
                         org-roam-capture--header-default))
          (org-template (org-capture-get :template))
          (roam-template (concat roam-head org-template)))
-    (when (file-exists-p file-path)
-      (error (format "File exists at %s, aborting" file-path)))
-    (org-roam-capture--put :orig-no-save (org-capture-get :no-save)
-                           :new-file t)
-    (org-capture-put :template
+    (unless (file-exists-p file-path)
+      (org-roam-capture--put :orig-no-save (org-capture-get :no-save)
+                             :new-file t)
+      (org-capture-put :template
                      ;; Fixes org-capture-place-plain-text throwing 'invalid search bound'
                      ;; when both :unnarowed t and "%?" is missing from the template string;
                      ;; may become unnecessary when the upstream bug is fixed
@@ -229,7 +228,7 @@ the file if the original value of :no-save is not t and
                          roam-template
                        (concat roam-template "%?"))
                      :type 'plain
-                     :no-save t)
+                     :no-save t))
     file-path))
 
 (defun org-roam-capture--expand-template ()
@@ -249,6 +248,10 @@ The file to use is dependent on the context:
 If the search is via title, it is assumed that the file does not
 yet exist, and Org-roam will attempt to create new file.
 
+If the search is via daily notes, 'time will be passed via
+`org-roam-capture--context'. This is used to alter the default
+time in `org-capture-templates'.
+
 If the search is via ref, it is matched against the Org-roam database.
 If there is no file with that ref, a file with that ref is created.
 
@@ -259,6 +262,9 @@ This function is used solely in Org-roam's capture templates: see
                       (or (cdr (assoc 'file org-roam-capture--info))
                           (org-roam-capture--new-file)))
                      ('title
+                      (org-roam-capture--new-file))
+                     ('dailies
+                      (org-capture-put :default-time (cdr (assoc 'time org-roam-capture--info)))
                       (org-roam-capture--new-file))
                      ('ref
                       (let ((completions (org-roam--get-ref-path-completions))

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -59,6 +59,14 @@
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam--set-up-buffer 'org-roam-buffer--get-create
   "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-today 'org-roam-dailies-today
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-tomorrow 'org-roam-dailies-tomorrow
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-yesterday 'org-roam-dailies-yesterday
+  "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-date 'org-roam-dailies-date
+  "org-roam 1.0.0")
 
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
@@ -69,6 +77,11 @@
   'org-roam-db--connection "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam--current-buffer
   'org-roam-buffer--current "org-roam 1.0.0")
+
+(define-obsolete-variable-alias 'org-roam-date-title-format
+  'org-roam-dailies-capture-templates "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam-date-filename-format
+  'org-roam-dailies-capture-templates "org-roam 1.0.0")
 
 (provide 'org-roam-compat)
 

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -1,0 +1,81 @@
+;;; org-roam-dialies.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t -*-
+;;;
+;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
+
+;; Author: Jethro Kuan <jethrokuan95@gmail.com>
+;; URL: https://github.com/jethrokuan/org-roam
+;; Keywords: org-mode, roam, convenience
+;; Version: 1.0.0-rc1
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; This library provides functionality for creating daily notes. This is a
+;; concept borrowed from Roam Research.
+;;
+;;; Code:
+;;; Library Requires
+(require 'org-capture)
+(require 'org-roam-capture)
+
+(defvar org-roam-dailies-capture-templates
+  '(("d" "daily" plain (function org-roam-capture--get-point)
+     ""
+     :immediate-finish t
+     :file-name "%<%Y-%m-%d>"
+     :head "#+TITLE: %<%Y-%m-%d>"))
+  "Capture templates for daily notes in Org-roam.")
+
+;; Declarations
+(declare-function org-roam--file-path-from-id "org-roam")
+
+(defun org-roam-dailies--file-for-time (time)
+  "Create and find file for TIME."
+  (let ((org-roam-capture-templates org-roam-dailies-capture-templates)
+        (org-roam-capture--info (list (cons 'time time)))
+        (org-roam-capture--context 'dailies))
+    (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
+    (org-roam--capture)))
+
+(defun org-roam-dailies-today ()
+  "Create and find the daily note for today."
+  (interactive)
+  (org-roam-dailies--file-for-time (current-time)))
+
+(defun org-roam-dailies-tomorrow (n)
+  "Create and find the daily note for tomorrow.
+With numeric argument N, use N days in the future."
+  (interactive "p")
+  (org-roam-dailies--file-for-time (time-add (* n 86400) (current-time))))
+
+(defun org-roam-dailies-yesterday (n)
+  "Create and find the file for yesterday.
+With numeric argument N, use N days in the past."
+  (interactive "p")
+  (org-roam-tomorrow (- n)))
+
+(defun org-roam-dailies-date ()
+  "Create the file for any date using the calendar interface."
+  (interactive)
+  (let ((time (org-read-date nil 'to-time nil "Date:  ")))
+    (org-roam-dailies--file-for-time time)))
+
+(provide 'org-roam-dailies)
+;;; org-roam-dailies.el ends here

--- a/org-roam.el
+++ b/org-roam.el
@@ -50,6 +50,7 @@
 (require 'org-roam-capture)
 (require 'org-roam-graph)
 (require 'org-roam-completion)
+(require 'org-roam-dailies)
 
 ;; To detect cite: links
 (require 'org-ref nil t)
@@ -435,17 +436,6 @@ INFO is an alist containing additional information."
                                                            :require-match t)))
       (switch-to-buffer (cdr (assoc name names-and-buffers))))))
 
-;;;; Daily notes
-(defcustom org-roam-date-title-format "%Y-%m-%d"
-  "Format string passed to `format-time-string' for getting a date file's title."
-  :type 'string
-  :group 'org-roam)
-
-(defcustom org-roam-date-filename-format "%Y-%m-%d"
-  "Format string passed to `format-time-string' for getting a date file's filename."
-  :type 'string
-  :group 'org-roam)
-
 (defun org-roam--file-path-from-id (id)
   "The file path for an Org-roam file, with identifier ID."
   (file-truename
@@ -454,47 +444,6 @@ INFO is an alist containing additional information."
         (concat id ".org.gpg")
       (concat id ".org"))
     org-roam-directory)))
-
-(defun org-roam--file-for-time (time)
-  "Create and find file for TIME."
-  (let* ((title (format-time-string org-roam-date-title-format time))
-         (filename (format-time-string org-roam-date-filename-format time))
-         (file-path (org-roam--file-path-from-id filename)))
-    (if (file-exists-p file-path)
-        (find-file file-path)
-      (let ((org-roam-capture-templates (list (list "d" "daily" 'plain (list 'function #'org-roam-capture--get-point)
-                                                    ""
-                                                    :immediate-finish t
-                                                    :file-name "${filename}"
-                                                    :head "#+TITLE: ${title}")))
-            (org-roam-capture--context 'title)
-            (org-roam-capture--info (list (cons 'title title)
-                                          (cons 'filename filename))))
-        (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-        (org-roam--capture)))))
-
-(defun org-roam-today ()
-  "Create and find file for today."
-  (interactive)
-  (org-roam--file-for-time (current-time)))
-
-(defun org-roam-tomorrow (n)
-  "Create and find the file for tomorrow.
-With numeric argument N, use N days in the future."
-  (interactive "p")
-  (org-roam--file-for-time (time-add (* n 86400) (current-time))))
-
-(defun org-roam-yesterday (n)
-  "Create and find the file for yesterday.
-With numeric argument N, use N days in the past."
-  (interactive "p")
-  (org-roam-tomorrow (- n)))
-
-(defun org-roam-date ()
-  "Create the file for any date using the calendar."
-  (interactive)
-  (let ((time (org-read-date nil 'to-time nil "Date:  ")))
-    (org-roam--file-for-time time)))
 
 ;;; The org-roam buffer
 ;;;; org-roam-link-face


### PR DESCRIPTION
###### Motivation for this change
This moves all the daily notes functionality into `org-roam-dailies.el`.

Beyond just an extraction, this is also a simplification. It removes two
variables: `org-roam-date-filename-format` and
`org-roam-date-title-format`, in favour of directly specifying them in
the `org-roam-dailies-capture-templates`.

`org-roam--file-for-time` is also vastly simplified to use org-capture's
default time expansion utilities, by setting the capture template's
`:default-time` appropriately.

Fixes #468 