### PR TITLE
(fix) ensure that directory exists before capturing to dir

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -217,6 +217,7 @@ the file if the original value of :no-save is not t and
                         org-roam-capture--header-default))
          (org-template (org-capture-get :template))
          (roam-template (concat roam-head org-template)))
+    (make-directory (file-name-directory file-path) t)
     (when (file-exists-p file-path)
       (error (format "File exists at %s, aborting" file-path)))
     (org-roam-capture--put :orig-no-save (org-capture-get :no-save)


### PR DESCRIPTION
Trying to create a note with `org-roam-find-file` inside a sub-directory that does not exist results in a silent failure.

This PR fixes it by ensuring the existence of the sub-directory (and its parents).