### PR TITLE
Optional `FILTER` argument for `org-roam-find-file` and `org-roam-insert`

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -357,6 +357,13 @@ If PREFIX, downcase the title before insertion."
 							       :capture-fn 'org-roam-insert))
 	(org-roam--capture)))))
 
+(defun org-roam-insert-non-ref (prefix)
+  "Find an Org-roam, non-ref file, and insert a relative org link to it at point.
+See `org-roam-insert' and
+`org-roam--get-non-ref-path-completions' for details."
+  (interactive "P")
+  (org-roam-insert prefix #'org-roam--get-non-ref-path-completions))
+
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
   "Return a list of cons pairs for titles to absolute path of Org-roam files."
@@ -410,6 +417,13 @@ CANDIDATES is a an alist of candidates to consider.  Defaults to
             (path (cdr candidate)))
         (unless (member path refs-path)
           (push (cons title path) completions))))))
+
+(defun org-roam-find-non-ref-file (&optional initial-prompt)
+  "Find and open an Org-roam, non-ref file.
+See `org-roam-find-files' and
+`org-roam--get-non-ref-path-completions' for details."
+  (interactive)
+  (org-roam-find initial prompt #'org-roam--get-non-ref-path-completions))
 
 ;;;; org-roam-find-directory
 (defun org-roam-find-directory ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -417,7 +417,7 @@ CANDIDATES is a an alist of candidates to consider.  Defaults to
             (path (cdr candidate)))
         (unless (member path refs-path)
           (setq completions (nconc completions
-                                   (list (cons title path)))))))))
+                                   (list candidate))))))))
 
 (defun org-roam-find-non-ref-file (&optional initial-prompt)
   "Find and open an Org-roam, non-ref file.

--- a/org-roam.el
+++ b/org-roam.el
@@ -372,21 +372,6 @@ If PREFIX, downcase the title before insertion."
                       file-path) res))))
     res))
 
-(defun org-roam--get-non-ref-path-completions (&optional candidates)
-  "Return a list of cons for titles of non-ref notes to absolute path.
-CANDIDATES is a an alist of candidates to consider.  Defaults to
-`org-roam--get-title-path-completions' otherwise."
-  (let* ((candidates (or candidates
-                         (org-roam--get-title-path-completions)))
-         (refs-path (->> (org-roam--get-ref-path-completions)
-                         (mapcar #'cdr)))
-         completions)
-    (dolist (candidate candidates (nreverse completions))
-      (let ((title (car candidate))
-            (path (cdr candidate)))
-        (unless (member path refs-path)
-          (push (cons title path) completions))))))
-
 (defun org-roam-find-file (&optional initial-prompt filter)
   "Find and open an Org-roam file.
 INITIAL-PROMPT is the initial title prompt.
@@ -410,6 +395,21 @@ takes as its argument an alist of path-completions.  See
               (org-roam-capture--context 'title))
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
           (org-roam--capture))))))
+
+(defun org-roam--get-non-ref-path-completions (&optional candidates)
+  "Return a list of cons for titles of non-ref notes to absolute path.
+CANDIDATES is a an alist of candidates to consider.  Defaults to
+`org-roam--get-title-path-completions' otherwise."
+  (let* ((candidates (or candidates
+                         (org-roam--get-title-path-completions)))
+         (refs-path (->> (org-roam--get-ref-path-completions)
+                         (mapcar #'cdr)))
+         completions)
+    (dolist (candidate candidates (nreverse completions))
+      (let ((title (car candidate))
+            (path (cdr candidate)))
+        (unless (member path refs-path)
+          (push (cons title path) completions))))))
 
 ;;;; org-roam-find-directory
 (defun org-roam-find-directory ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -319,8 +319,8 @@ specified via the #+ROAM_ALIAS property."
 (defun org-roam-insert (prefix &optional filter-fn)
   "Find an Org-roam file, and insert a relative org link to it at point.
 If PREFIX, downcase the title before insertion.
-FILTER-FN is the name of a function to apply on the candidates which
-takes as its argument an alist of path-completions.  See
+FILTER-FN is the name of a function to apply on the candidates
+which takes as its argument an alist of path-completions.  See
 `org-roam--get-title-path-completions' for details."
   (interactive "P")
   (unless (org-roam--org-roam-file-p
@@ -378,8 +378,8 @@ takes as its argument an alist of path-completions.  See
 (defun org-roam-find-file (&optional initial-prompt filter-fn)
   "Find and open an Org-roam file.
 INITIAL-PROMPT is the initial title prompt.
-FILTER-FN is the name of a function to apply on the candidates which
-takes as its argument an alist of path-completions.  See
+FILTER-FN is the name of a function to apply on the candidates
+which takes as its argument an alist of path-completions.  See
 `org-roam--get-title-path-completions' for details."
   (interactive)
   (let* ((completions (--> (org-roam--get-title-path-completions)

--- a/org-roam.el
+++ b/org-roam.el
@@ -412,11 +412,12 @@ CANDIDATES is a an alist of candidates to consider.  Defaults to
          (refs-path (->> (org-roam--get-ref-path-completions)
                          (mapcar #'cdr)))
          completions)
-    (dolist (candidate candidates (nreverse completions))
+    (dolist (candidate candidates completions)
       (let ((title (car candidate))
             (path (cdr candidate)))
         (unless (member path refs-path)
-          (push (cons title path) completions))))))
+          (setq completions (nconc completions
+                                   (list (cons title path)))))))))
 
 (defun org-roam-find-non-ref-file (&optional initial-prompt)
   "Find and open an Org-roam, non-ref file.

--- a/org-roam.el
+++ b/org-roam.el
@@ -369,6 +369,21 @@ If PREFIX, downcase the title before insertion."
                       file-path) res))))
     res))
 
+(defun org-roam--get-non-ref-path-completions (&optional candidates)
+  "Return a list of cons for titles of non-ref notes to absolute path.
+CANDIDATES is a an alist of candidates to consider.  Defaults to
+`org-roam--get-title-path-completions' otherwise."
+  (let* ((candidates (or candidates
+                         (org-roam--get-title-path-completions)))
+         (refs-path (->> (org-roam--get-ref-path-completions)
+                         (mapcar #'cdr)))
+         completions)
+    (dolist (candidate candidates (nreverse completions))
+      (let ((title (car candidate))
+            (path (cdr candidate)))
+        (unless (member path refs-path)
+          (push (cons title path) completions))))))
+
 (defun org-roam-find-file (&optional initial-prompt filter)
   "Find and open an Org-roam file.
 INITIAL-PROMPT is the initial title prompt.

--- a/org-roam.el
+++ b/org-roam.el
@@ -316,7 +316,7 @@ specified via the #+ROAM_ALIAS property."
      (concat "file:" (file-relative-name target here))
      description)))
 
-(defun org-roam-insert (prefix)
+(defun org-roam-insert (prefix &optional filter)
   "Find an Org-roam file, and insert a relative org link to it at point.
 If PREFIX, downcase the title before insertion."
   (interactive "P")
@@ -329,7 +329,10 @@ If PREFIX, downcase the title before insertion."
          (region-text (when region
                         (buffer-substring-no-properties
                          (car region) (cdr region))))
-         (completions (org-roam--get-title-path-completions))
+         (completions (--> (org-roam--get-title-path-completions)
+                           (if filter
+                               (funcall filter it)
+                             it)))
          (title (org-roam-completion--completing-read "File: " completions
                                                       :initial-input region-text))
          (region-or-title (or region-text title))

--- a/org-roam.el
+++ b/org-roam.el
@@ -360,13 +360,6 @@ takes as its argument an alist of path-completions.  See
 							       :capture-fn 'org-roam-insert))
 	(org-roam--capture)))))
 
-(defun org-roam-insert-non-ref (prefix)
-  "Find an Org-roam, non-ref file, and insert a relative org link to it at point.
-See `org-roam-insert' and
-`org-roam--get-non-ref-path-completions' for details."
-  (interactive "P")
-  (org-roam-insert prefix #'org-roam--get-non-ref-path-completions))
-
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
   "Return a list of cons pairs for titles to absolute path of Org-roam files."
@@ -405,29 +398,6 @@ takes as its argument an alist of path-completions.  See
               (org-roam-capture--context 'title))
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
           (org-roam--capture))))))
-
-(defun org-roam--get-non-ref-path-completions (&optional candidates)
-  "Return a list of cons for titles of non-ref notes to absolute path.
-CANDIDATES is a an alist of candidates to consider.  Defaults to
-`org-roam--get-title-path-completions' otherwise."
-  (let* ((candidates (or candidates
-                         (org-roam--get-title-path-completions)))
-         (refs-path (->> (org-roam--get-ref-path-completions)
-                         (mapcar #'cdr)))
-         completions)
-    (dolist (candidate candidates completions)
-      (let ((title (car candidate))
-            (path (cdr candidate)))
-        (unless (member path refs-path)
-          (setq completions (nconc completions
-                                   (list candidate))))))))
-
-(defun org-roam-find-non-ref-file (&optional initial-prompt)
-  "Find and open an Org-roam, non-ref file.
-See `org-roam-find-files' and
-`org-roam--get-non-ref-path-completions' for details."
-  (interactive)
-  (org-roam-find initial prompt #'org-roam--get-non-ref-path-completions))
 
 ;;;; org-roam-find-directory
 (defun org-roam-find-directory ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -318,7 +318,10 @@ specified via the #+ROAM_ALIAS property."
 
 (defun org-roam-insert (prefix &optional filter)
   "Find an Org-roam file, and insert a relative org link to it at point.
-If PREFIX, downcase the title before insertion."
+If PREFIX, downcase the title before insertion.
+FILTER is the name of a function to apply on the candidates which
+takes as its argument an alist of path-completions.  See
+`org-roam--get-title-path-completions' for details."
   (interactive "P")
   (unless (org-roam--org-roam-file-p
            (buffer-file-name (buffer-base-buffer)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -316,10 +316,10 @@ specified via the #+ROAM_ALIAS property."
      (concat "file:" (file-relative-name target here))
      description)))
 
-(defun org-roam-insert (prefix &optional filter)
+(defun org-roam-insert (prefix &optional filter-fn)
   "Find an Org-roam file, and insert a relative org link to it at point.
 If PREFIX, downcase the title before insertion.
-FILTER is the name of a function to apply on the candidates which
+FILTER-FN is the name of a function to apply on the candidates which
 takes as its argument an alist of path-completions.  See
 `org-roam--get-title-path-completions' for details."
   (interactive "P")
@@ -333,8 +333,8 @@ takes as its argument an alist of path-completions.  See
                         (buffer-substring-no-properties
                          (car region) (cdr region))))
          (completions (--> (org-roam--get-title-path-completions)
-                           (if filter
-                               (funcall filter it)
+                           (if filter-fn
+                               (funcall filter-fn it)
                              it)))
          (title (org-roam-completion--completing-read "File: " completions
                                                       :initial-input region-text))
@@ -375,16 +375,16 @@ takes as its argument an alist of path-completions.  See
                       file-path) res))))
     res))
 
-(defun org-roam-find-file (&optional initial-prompt filter)
+(defun org-roam-find-file (&optional initial-prompt filter-fn)
   "Find and open an Org-roam file.
 INITIAL-PROMPT is the initial title prompt.
-FILTER is the name of a function to apply on the candidates which
+FILTER-FN is the name of a function to apply on the candidates which
 takes as its argument an alist of path-completions.  See
 `org-roam--get-title-path-completions' for details."
   (interactive)
   (let* ((completions (--> (org-roam--get-title-path-completions)
-                           (if filter
-                               (funcall filter it)
+                           (if filter-fn
+                               (funcall filter-fn it)
                              it)))
          (title (org-roam-completion--completing-read "File: " completions
                                                       :initial-input initial-prompt))

--- a/org-roam.el
+++ b/org-roam.el
@@ -369,11 +369,17 @@ If PREFIX, downcase the title before insertion."
                       file-path) res))))
     res))
 
-(defun org-roam-find-file (&optional initial-prompt)
+(defun org-roam-find-file (&optional initial-prompt filter)
   "Find and open an Org-roam file.
-INITIAL-PROMPT is the initial title prompt."
+INITIAL-PROMPT is the initial title prompt.
+FILTER is the name of a function to apply on the candidates which
+takes as its argument an alist of path-completions.  See
+`org-roam--get-title-path-completions' for details."
   (interactive)
-  (let* ((completions (org-roam--get-title-path-completions))
+  (let* ((completions (--> (org-roam--get-title-path-completions)
+                           (if filter
+                               (funcall filter it)
+                             it)))
          (title (org-roam-completion--completing-read "File: " completions
                                                       :initial-input initial-prompt))
          (file-path (cdr (assoc title completions))))


### PR DESCRIPTION
Motivation is described in #474.

Implements:
- Optional `FILTER` argument for `org-roam-find-file` and `org-roam-insert`
- `org-roam--get-non-ref-path-completions` to only get non-ref notes
- `org-roam-find-non-ref-file` & `org-roam-insert-non-ref` as convenience commands

Closes #474.