### PR TITLE
(feat): Use TITLE as description when linking before first heading

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -540,6 +540,15 @@ for Org-ref cite links."
                       :order-by (asc from)]
                      target))
 
+(defun org-roam-store-link ()
+  "Store a link to an `org-roam' file."
+  (when (org-before-first-heading-p)
+    (when-let ((title (cdr (assoc "TITLE" (org-roam--extract-global-props '("TITLE"))))))
+      (org-link-store-props
+       :type        "file"
+       :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
+       :description title))))
+
 ;;;###autoload
 (defalias 'org-roam 'org-roam-buffer-toggle-display)
 
@@ -594,7 +603,7 @@ Otherwise, behave as if called interactively."
     (setq org-roam-last-window (get-buffer-window))
     (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
     (add-hook 'after-save-hook #'org-roam-db--update-file nil t)
-    (org-link-set-parameters "file" :face 'org-roam--roam-link-face)
+    (org-link-set-parameters "file" :face 'org-roam--roam-link-face :store #'org-roam-store-link)
     (org-roam-buffer--update-maybe :redisplay t)))
 
 (defun org-roam--delete-file-advice (file &optional _trash)


### PR DESCRIPTION
Fixes #487

###### Motivation for this change

#487 
IMO, this is especially useful because the file name is automatically generated in org roam.
