### PR TITLE
(internal): Simplify `org-roam--list-files` implementation.

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -174,22 +174,11 @@ If FILE is not specified, use the current buffer's file-path."
 (defun org-roam--list-files (dir)
   "Return all Org-roam files located within DIR, at any nesting level.
 Ignores hidden files and directories."
-  (if (file-exists-p dir)
-      (let ((files (directory-files dir t "." t))
-            (dir-ignore-regexp (concat "\\(?:"
-                                       "\\."
-                                       "\\|\\.\\."
-                                       "\\)$"))
-            result)
-        (dolist (file files)
-          (cond
-           ((file-directory-p file)
-            (unless (string-match dir-ignore-regexp file)
-              (setq result (append (org-roam--list-files file) result))))
-           ((and (file-readable-p file)
-                 (org-roam--org-file-p file))
-            (setq result (cons (file-truename file) result)))))
-        result)))
+  (let ((regex (concat "\\.\\(?:"(mapconcat #'regexp-quote org-roam-file-extensions "\\|" )"\\)\\(?:\\.gpg\\)?\\'"))
+	result)
+    (dolist (file (directory-files-recursively dir regex) result)
+      (when (and (file-readable-p file) (org-roam--org-file-p file))
+	(push file result)))))
 
 (defun org-roam--list-all-files ()
   "Return a list of all Org-roam files within `org-roam-directory'."


### PR DESCRIPTION
Use destructive elisp functions to optimize for speed and memory
usage.

Refs #104

###### Motivation for this change

slight speedup:
Original:
```
ELISP> (benchmark 1000 '(org-roam--list-files org-roam-directory))
"Elapsed time: 29.403994s (6.193575s in 122 GCs)"
```
Commit:
```
ELISP> (benchmark 1000 '(org-roam--list-files org-roam-directory))
"Elapsed time: 27.186161s (5.973992s in 117 GCs)"
```