### PR TITLE
(docs): Fix org-roam-protocol JS Bookmarklet

### DIFF
--- a/doc/roam_protocol.md
+++ b/doc/roam_protocol.md
@@ -20,7 +20,7 @@ To use this, create a Firefox bookmarklet as follows:
 
 ```javascript
 javascript:location.href =
-'org-protocol:/roam-ref?template=r&ref='
+'org-protocol://roam-ref?template=r&ref='
 + encodeURIComponent(location.href)
 + '&title='
 + encodeURIComponent(document.title)


### PR DESCRIPTION
###### Motivation for this change
JS Bookmarklet for org-roam-protocol was missing extra `/` in documentation.