### PR TITLE
(bugfix): fix inserting backup files into database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1 (TBD)
+
+### Bugfixes
+* [#509](https://github.com/jethrokuan/org-roam/pull/509) fix backup files being tracked in database
+* [#509](https://github.com/jethrokuan/org-roam/pull/509) fix external org files being tracked in database
+
 ## 1.1.0 (21-04-2020)
 
 To the average user, this release is mainly a bugfix release with additional options to customize. However, the changes made to the source is significant. Most notably, in this release:

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -330,16 +330,16 @@ including the file itself.  If the file does not have any connections, nil is re
 
 (defun org-roam-db--update-file (&optional file-path)
   "Update Org-roam cache for FILE-PATH."
-  (let (buf)
-    (if file-path
-        (setq buf (find-file-noselect file-path))
-      (setq buf (current-buffer)))
-    (with-current-buffer buf
-      (save-excursion
-        (org-roam-db--update-titles)
-        (org-roam-db--update-refs)
-        (org-roam-db--update-cache-links)
-        (org-roam-buffer--update-maybe :redisplay t)))))
+  (when (org-roam--org-roam-file-p file-path)
+    (let ((buf (or (and file-path
+                        (find-file-noselect file-path))
+                   (current-buffer))))
+      (with-current-buffer buf
+        (save-excursion
+          (org-roam-db--update-titles)
+          (org-roam-db--update-refs)
+          (org-roam-db--update-cache-links)
+          (org-roam-buffer--update-maybe :redisplay t))))))
 
 ;;;;; org-roam-db-build-cache
 (defun org-roam-db-build-cache ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -167,18 +167,19 @@ If FILE is not specified, use the current buffer's file-path."
   (if-let ((path (or file
                   (buffer-file-name))))
       (save-match-data
-	(org-roam--org-file-p path)
-	(f-descendant-of-p (file-truename path)
-			   (file-truename org-roam-directory)))))
+        (and
+         (org-roam--org-file-p path)
+         (f-descendant-of-p (file-truename path)
+                            (file-truename org-roam-directory))))))
 
 (defun org-roam--list-files (dir)
   "Return all Org-roam files located within DIR, at any nesting level.
 Ignores hidden files and directories."
   (let ((regex (concat "\\.\\(?:"(mapconcat #'regexp-quote org-roam-file-extensions "\\|" )"\\)\\(?:\\.gpg\\)?\\'"))
-	result)
+        result)
     (dolist (file (directory-files-recursively dir regex) result)
       (when (and (file-readable-p file) (org-roam--org-file-p file))
-	(push file result)))))
+        (push file result)))))
 
 (defun org-roam--list-all-files ()
   "Return a list of all Org-roam files within `org-roam-directory'."


### PR DESCRIPTION
###### Motivation for this change

In #470, the `and` clause was removed, so `org-roam--org-roam-file-p`
returns `t` on `foo.org~` backup files. This PR adds that back in.

In addition, the `after-save-hook` function was not checking for whether
the file was within the org-roam system, which meant files from outside
`org-roam` would also be added into the database. This PR adds a guard
clause.