### PR TITLE
(bugfix): Fix invalid usage of error handler

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -216,7 +216,7 @@ into a digraph."
      (if (executable-find org-roam-graph-viewer)
          (condition-case err
              (call-process org-roam-graph-viewer nil 0 nil file)
-           ((error (user-error "Failed to open org-roam graph: %s" err))))
+           (error (user-error "Failed to open org-roam graph: %s" err)))
        (user-error "Executable not found: \"%s\"" org-roam-graph-viewer)))
     ((pred functionp) (funcall org-roam-graph-viewer file))
     ('nil (view-file file))


### PR DESCRIPTION
The error handler was never invoked when executing
`org-roam-graph-viewer` failed

###### Motivation for this change

No signal when executing `org-roam-graph-viewer` failed.

BTW: It would be nice to make byte compile errors fatal in the CI jobs. The above error was also revealed when byte-compiling:

```
In toplevel form:
org-roam-graph.el:212:1:Warning: Unused lexical variable ‘err’


```

