### PR TITLE
(feat) implement org-roam-find-index

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -77,6 +77,21 @@ Org-roam files are created and prefilled using Org-roam's templating
 system. The templating system is customizable, and the system is
 described in detail in the [Org-roam Template](templating.md) page.
 
+### Index
+
+As your collection grows, you might want to create an index where you keep
+links to your main files.
+
+In Org-roam, you can define the path to your index file by setting `org-roam-index-file`.
+
+```emacs-lisp
+(setq org-roam-index-file "index.org")
+```
+
+You can then bind `org-roam-find-index` in your configuration to access it (see [Basic Install and
+Configuration](installation.md/#basic-install-and-configuration) to review how
+to set key-bindings).
+
 ### Encryption
 
 Encryption (via GPG) can be enabled for all new files by setting

--- a/org-roam.el
+++ b/org-roam.el
@@ -422,9 +422,9 @@ whose title is 'Index'."
                  (wrong-type (signal 'wrong-type-argument
                                      `((functionp stringp)
                                        ,wrong-type))))))
-    (pcase index
-      ((pred (f-relative-p)) (concat (file-truename org-roam-directory) path))
-      (_ index))))
+    (if (f-relative-p index)
+        (concat (file-truename org-roam-directory) path)
+      index)))
 
 (defun org-roam-find-index ()
   "Find the index file in `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -417,7 +417,7 @@ whose title is 'Index'."
   (let* ((index org-roam-index-file)
          (path (pcase index
                  ((pred functionp) (funcall index))
-                 ((pred stringp) index)
+                 ((or (pred stringp) 'nil) index)
                  (wrong-type (signal 'wrong-type-argument
                                      `((functionp stringp)
                                        ,wrong-type))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -403,7 +403,7 @@ absolute.
 If it is not defined, the index is assumed to be a note in
 `org-roam-directory' whose title is 'Index'.")
 
-(defun org-roam--find-index ()
+(defun org-roam--get-index-path ()
   "Return the path to the index in `org-roam-directory'.
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, it is assumed to be a note in `org-roam-directory'
@@ -423,7 +423,7 @@ Otherwise, the function will look in your `org-roam-directory'
 for a note whose title is 'Index'.  If it does not exist, the
 command will offer you to create one."
   (interactive)
-  (let ((index (org-roam--find-index)))
+  (let ((index (org-roam--get-index-path)))
     (if (and index
              (file-exists-p index))
         (find-file index)

--- a/org-roam.el
+++ b/org-roam.el
@@ -436,7 +436,7 @@ command will offer you to create one."
     (if (and index
              (file-exists-p index))
         (find-file index)
-      (when (y-or-n-p "Index file does not exist.  Would you like to create it?")
+      (when (y-or-n-p? "Index file does not exist.  Would you like to create it?")
         (org-roam-find-file "Index")))))
 
 ;;;; org-roam-find-ref

--- a/org-roam.el
+++ b/org-roam.el
@@ -437,7 +437,7 @@ command will offer you to create one."
     (if (and index
              (file-exists-p index))
         (find-file index)
-      (when (y-or-n-p? "Index file does not exist.  Would you like to create it?")
+      (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
         (org-roam-find-file "Index")))))
 
 ;;;; org-roam-find-ref

--- a/org-roam.el
+++ b/org-roam.el
@@ -421,12 +421,10 @@ whose title is 'Index'."
                  (wrong-type (signal 'wrong-type-argument
                                      `((functionp stringp)
                                        ,wrong-type))))))
-    (or (and org-roam-index-file
-             (if (f-relative-p path)
-                 (concat (file-truename org-roam-directory) path)
-               path))
-        (cdr (assoc "Index"
-                    (org-roam--get-title-path-completions))))))
+    (pcase index
+      ('nil (cdr (assoc "Index" (org-roam--get-title-path-completions))))
+      ((pred (f-relative-p)) (concat (file-truename org-roam-directory) path))
+      (_ index))))
 
 (defun org-roam-find-index ()
   "Find the index file in `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -414,10 +414,13 @@ assumed to be a note in `org-roam-directory' whose title is
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, it is assumed to be a note in `org-roam-directory'
 whose title is 'Index'."
-  (let ((path (--> org-roam-index-file
-                   (if (functionp it)
-                       (funcall it)
-                     it))))
+  (let* ((index org-roam-index-file)
+         (path (pcase index
+                 ((pred functionp) (funcall index))
+                 ((pred stringp) index)
+                 (wrong-type (signal 'wrong-type-argument
+                                     `((functionp stringp)
+                                       ,wrong-type))))))
     (or (and org-roam-index-file
              (if (f-relative-p path)
                  (concat (file-truename org-roam-directory) path)

--- a/org-roam.el
+++ b/org-roam.el
@@ -395,6 +395,41 @@ which takes as its argument an alist of path-completions.  See
   (interactive)
   (find-file org-roam-directory))
 
+;;;; org-roam-find-index
+(defcustom org-roam-index-file nil
+  "Path to the Org-roam index file.
+The path can either be relative (to `org-roam-directory') or
+absolute.
+If it is not defined, the index is assumed to be a note in
+`org-roam-directory' whose title is 'Index'.")
+
+(defun org-roam--find-index ()
+  "Return the path to the index in `org-roam-directory'.
+The path to the index can be defined in `org-roam-index-file'.
+Otherwise, it is assumed to be a note in `org-roam-directory'
+whose title is 'Index'."
+  (let ((path org-roam-index-file))
+    (or (and org-roam-index-file
+             (if (f-relative-p path)
+                 (concat (file-truename org-roam-directory) path)
+               path))
+        (cdr (assoc "Index"
+                    (org-roam--get-title-path-completions))))))
+
+(defun org-roam-find-index ()
+  "Find the index file in `org-roam-directory'.
+The path to the index can be defined in `org-roam-index-file'.
+Otherwise, the function will look in your `org-roam-directory'
+for a note whose title is 'Index'.  If it does not exist, the
+command will offer you to create one."
+  (interactive)
+  (let ((index (org-roam--find-index)))
+    (if (and index
+             (file-exists-p index))
+        (find-file index)
+      (when (y-or-n-p "Index file does not exist.  Would you like to create it?")
+        (org-roam-find-file "Index")))))
+
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()
   "Return a list of cons pairs for refs to absolute path of Org-roam files."

--- a/org-roam.el
+++ b/org-roam.el
@@ -417,12 +417,12 @@ whose title is 'Index'."
   (let* ((index org-roam-index-file)
          (path (pcase index
                  ((pred functionp) (funcall index))
-                 ((or (pred stringp) 'nil) index)
+                 ((pred stringp) index)
+                 ('nil (user-error "You need to set `org-roam-index-file' before you can jump to it"))
                  (wrong-type (signal 'wrong-type-argument
                                      `((functionp stringp)
                                        ,wrong-type))))))
     (pcase index
-      ('nil (cdr (assoc "Index" (org-roam--get-title-path-completions))))
       ((pred (f-relative-p)) (concat (file-truename org-roam-directory) path))
       (_ index))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -398,17 +398,26 @@ which takes as its argument an alist of path-completions.  See
 ;;;; org-roam-find-index
 (defcustom org-roam-index-file nil
   "Path to the Org-roam index file.
-The path can either be relative (to `org-roam-directory') or
-absolute.
-If it is not defined, the index is assumed to be a note in
-`org-roam-directory' whose title is 'Index'.")
+The path can be a string or a function.  If it is a string, it
+should be the path (absolute or relative to `org-roam-directory')
+to the index file.  If it is is a function, the function should
+return the path to the index file.  Otherwise, the index is
+assumed to be a note in `org-roam-directory' whose title is
+'Index'."
+  :type '(choice
+          (string :tag "Path to index" "%s")
+          (function :tag "Function to generate the path"))
+  :group 'org-roam)
 
 (defun org-roam--get-index-path ()
   "Return the path to the index in `org-roam-directory'.
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, it is assumed to be a note in `org-roam-directory'
 whose title is 'Index'."
-  (let ((path org-roam-index-file))
+  (let ((path (--> org-roam-index-file
+                   (if (functionp it)
+                       (funcall it)
+                     it))))
     (or (and org-roam-index-file
              (if (f-relative-p path)
                  (concat (file-truename org-roam-directory) path)


### PR DESCRIPTION
Implement a new command `org-roam-find-index` and helper function `org-roam--find-index` (note the `--` for internal) for finding an index file in `org-roam-directory`.

The resources I've read on the slip-box indicated that one should maintain an index file to lead you to your topic-notes.  From Ahrens (2017):
> After adding a note to the slip-box, **we need to make sure it can be found again**. This is what the index is for.
[…]
The organisation of the notes is in the network of references in the slip-box, so all we need from the index are entry points. A few wisely chosen notes are sufficient for each entry point. **The quicker we get from the index to the concrete notes, the quicker we move our attention from mentally preconceived ideas towards the fact-rich level of interconnected content, where we can conduct a fact-based dialogue with the slip-box**. [emphasis added]

So, I think it might be useful to *recommend* users to create an index file, and to provide a command to access it.  I've proposed an extensible way to match the index.  For now:
- The path to the index file, relative or absolute, can be defined in`org-roam-index-file`.
- Otherwise, the default is to select an Org-roam note whose `#+TITLE:` is `Index`.
- If neither of those options is satisfied, the command offer to create it for you via `org-roam-find-file`.

References:
- <div class="csl-bib-body" style="line-height: 1.35; margin-left: 2em; text-indent:-2em;">
  <div class="csl-entry">Ahrens, Sönke. <i>How to Take Smart Notes: One Simple Technique to Boost Writing, Learning and Thinking for Students, Academics and Nonfiction Book Writers</i>, 2017.</div>
  <span class="Z3988" title="url_ver=Z39.88-2004&amp;ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fzotero.org%3A2&amp;rft_id=urn%3Aisbn%3A978-1-5428-6650-7&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=book&amp;rft.btitle=How%20to%20Take%20Smart%20Notes%3A%20One%20Simple%20Technique%20to%20Boost%20Writing%2C%20Learning%20and%20Thinking%20for%20Students%2C%20Academics%20and%20Nonfiction%20Book%20Writers&amp;rft.aufirst=S%C3%B6nke&amp;rft.aulast=Ahrens&amp;rft.au=S%C3%B6nke%20Ahrens&amp;rft.date=2017&amp;rft.isbn=978-1-5428-6650-7&amp;rft.language=English"></span>
</div>