### PR TITLE
(feat) expand rel-links upon extraction

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -200,18 +200,24 @@ The search terminates when the first property is encountered."
         (push (cons prop p) res)))
     res))
 
+(defvar org-roam--org-link-file-bracket-re
+  "\\[\\[file:\\(\\(?:[^][\\]\\|\\\\\\(?:\\\\\\\\\\)*[][]\\|\\\\+[^][]\\)+\\)]\\(?:\\[\\(\\(?:.\\|
+\\)+?\\)]\\)?]"
+  "Matches a 'file:' link in double brackets.")
+
 (defun org-roam--expand-links (content path)
   "Crawl CONTENT for relative links and expand them.
 PATH should be the root from which to compute the relativity."
-  (let ((dir (file-name-directory path)))
+  (let ((dir (file-name-directory path))
+        (re org-roam--org-link-file-bracket-re))
     (with-temp-buffer
       (insert content)
       (goto-char (point-min))
       ;; Loop over links
-      (while (re-search-forward org-link-bracket-re (point-max) t)
+      (while (re-search-forward re (point-max) t)
         (goto-char (match-beginning 1))
         ;; Strip 'file:'
-        (setq link (substring (match-string 1) 5))
+        (setq link (match-string 1))
         ;; Delete relative link
         (when (f-relative-p link)
           (delete-region (match-beginning 1)

--- a/org-roam.el
+++ b/org-roam.el
@@ -200,6 +200,26 @@ The search terminates when the first property is encountered."
         (push (cons prop p) res)))
     res))
 
+(defun org-roam--expand-links (content path)
+  "Crawl CONTENT for relative links and expand them.
+PATH should be the root from which to compute the relativity."
+  (let ((dir (file-name-directory path)))
+    (with-temp-buffer
+      (insert content)
+      (goto-char (point-min))
+      ;; Loop over links
+      (while (re-search-forward org-link-bracket-re (point-max) t)
+        (goto-char (match-beginning 1))
+        ;; Strip 'file:'
+        (setq link (substring (match-string 1) 5))
+        ;; Delete relative link
+        (when (f-relative-p link)
+          (delete-region (match-beginning 1)
+                         (match-end 1))
+          (insert (expand-file-name
+                   (concat dir link)))))
+      (buffer-string))))
+
 (defun org-roam--extract-links (&optional file-path)
   "Extracts all link items within the current buffer.
 Link items are of the form:
@@ -231,11 +251,13 @@ it as FILE-PATH."
                    (begin (or (org-element-property :content-begin element)
                               (org-element-property :begin element)))
                    (content (or (org-element-property :raw-value element)
-                                (buffer-substring
+                                (buffer-substring-no-properties
                                  begin
                                  (or (org-element-property :content-end element)
                                      (org-element-property :end element)))))
-                   (content (string-trim content)))
+                   (content (string-trim content))
+                   ;; Expand all relative links to absolute links
+                   (content (org-roam--expand-links content file-path)))
               (vector file-path
                       (cond ((string= link-type "roam")
                              (file-truename (expand-file-name path (file-name-directory file-path))))


### PR DESCRIPTION
Fixes #517.

-----

Here's a prototype to address #517 (and help with #516).

The links created by `org-roam-insert` are relative.  This is well an good until we need to handle those relative links in `org-roam-buffer`.  The problem is `org-roam-buffer` is buffer-agnostic, and therefore file-path-agnostic as well.  Since we do not have the root from which to compute the relativity, we cannot reliably get the absolute path of a backlink.

#516 attempted to resolve the issue by exploiting the fact that `org-roam-buffer--insert-backlinks` inserted those backlinks under a heading which contained the absolute path to the file in which those backlinks were found.  It worked, yes, but it was hackish.  Also, it only covered an effect of the problem rather than its cause.

#517 then came along with its targeting problem, and it led me to think about the way we store those backlinks in the database.  This in turn led me to `org-roam--extract-links`.

There's a lot going on in that function, but I'm only modifying the way `content` is stored in the database.  Think of `content` as the neighbouring content, the line you see below a backlink (highlighted below):
![screenshot-43ITJMHZDj](https://user-images.githubusercontent.com/12202828/80290915-35036a00-8749-11ea-8c53-da3ee09a026e.png)

I'm running the content through the `org-roam--expand-links` which expands all the relative links, and returns the resulting string.

-----

This implementation is working, but there are a couple of things bugging me:
1. I've had to replace `buffer-substring` with `buffer-substring-no-properties` because I wanted to avoid modifying them.  As far as I can see, this is not a problem for now since `org-roam-buffer` still depends on `org-mode`, which means that the proper fontification is applied.  Since the formatting of the links also depends on `org-mode`, I think this is not a big deal.
2. The whole thing has this hack-ish quality to it that I don't like.  We might be able to find a better to store the content inside the database.  I'm not good with text-properties or with `org-element-property`, so I could only do a rudimentary job.
