### PR TITLE
(feat) conditionally pluralize heading in org-roam-buffer

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -108,8 +108,9 @@ When non-nil, the window will not be closed when deleting other windows."
             (key-backlinks (org-roam--get-backlinks (s-chop-prefix "cite:" roam-key)))
             (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
       (progn
-        (insert (format "\n\n* %d Cite backlinks\n"
-                        (length key-backlinks)))
+        (insert (let ((l (length key-backlinks)))
+                  (format "\n\n* %d Cite backlink%s\n"
+                          l (if (> l 1) "s" ""))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))
@@ -133,8 +134,9 @@ When non-nil, the window will not be closed when deleting other windows."
             (backlinks (org-roam--get-backlinks file-path))
             (grouped-backlinks (--group-by (nth 0 it) backlinks)))
       (progn
-        (insert (format "\n\n* %d Backlinks\n"
-                        (length backlinks)))
+        (insert (let ((l (length backlinks)))
+                     (format "\n\n* %d Backlink%s\n"
+                             l (if (> l 1) "s" ""))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -100,6 +100,16 @@ When non-nil, the window will not be closed when deleting other windows."
                        'font-lock-face
                        'org-document-title)))
 
+(defun org-roam--pluralize (string number)
+  "Conditionally pluralize STRING if NUMBER is above 1."
+  (let ((l (pcase number
+             ((pred (listp)) (length number))
+             ((pred (integerp)) number)
+             (wrong-type (signal 'wrong-type-argument
+                                 `((listp integerp)
+                                   ,wrong-type))))))
+    (format "%s%s" string (if (> l 1) "s" ""))))
+
 (defun org-roam-buffer--insert-citelinks ()
   "Insert citation backlinks for the current buffer."
   (if-let* ((roam-key (with-temp-buffer
@@ -109,8 +119,8 @@ When non-nil, the window will not be closed when deleting other windows."
             (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
       (progn
         (insert (let ((l (length key-backlinks)))
-                  (format "\n\n* %d Cite backlink%s\n"
-                          l (if (> l 1) "s" ""))))
+                  (format "\n\n* %d %s\n"
+                          l (org-roam--pluralize "Cite backlink" l))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))
@@ -135,8 +145,8 @@ When non-nil, the window will not be closed when deleting other windows."
             (grouped-backlinks (--group-by (nth 0 it) backlinks)))
       (progn
         (insert (let ((l (length backlinks)))
-                     (format "\n\n* %d Backlink%s\n"
-                             l (if (> l 1) "s" ""))))
+                     (format "\n\n* %d %s\n"
+                             l (org-roam--pluralize "Backlink" l))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))


### PR DESCRIPTION
Prompted by #520.

I've noticed that we didn't have a switch between singular and plural for the titles in `org-roam-buffer`:
![screenshot-43ITJMHZDj](https://user-images.githubusercontent.com/12202828/80290915-35036a00-8749-11ea-8c53-da3ee09a026e.png)

So, I went ahead and implemented it.

![screenshot-W1OafD3HcY](https://user-images.githubusercontent.com/12202828/80291342-06878e00-874d-11ea-972b-bea4a2ada28e.png)

Note that I've also done it for cite backlinks.