### PR TITLE
(bugfix): quote graphviz configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 * [#509](https://github.com/jethrokuan/org-roam/pull/509) fix backup files being tracked in database
 * [#509](https://github.com/jethrokuan/org-roam/pull/509) fix external org files being tracked in database
+* [#537](https://github.com/jethrokuan/org-roam/pull/537) quote graphviz node and edge configuration options to allow multi-word configurations
 
 ## 1.1.0 (21-04-2020)
 

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -163,7 +163,8 @@ into a digraph."
         (insert (org-roam-graph--dot-option option) ";\n"))
       (dolist (attribute '("node" "edge"))
         (insert (format " %s [%s];\n" attribute
-                        (mapconcat #'org-roam-graph--dot-option
+                        (mapconcat (lambda (var)
+                                     (org-roam-graph--dot-option var nil "\""))
                                    (symbol-value
                                     (intern (concat "org-roam-graph-" attribute "-extra-config")))
                                    ","))))


### PR DESCRIPTION
###### Motivation for this change

Always quote graphviz configuration options. This allows passing
configurations with spaces. Fixes #535.