### PR TITLE
(feat): optionally use headline as title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * [#509](https://github.com/jethrokuan/org-roam/pull/509) fix external org files being tracked in database
 * [#537](https://github.com/jethrokuan/org-roam/pull/537) quote graphviz node and edge configuration options to allow multi-word configurations
 
+### Features
+* [#538](https://github.com/jethrokuan/org-roam/pull/538) Optionally use text in first headline as title 
+
 ## 1.1.0 (21-04-2020)
 
 To the average user, this release is mainly a bugfix release with additional options to customize. However, the changes made to the source is significant. Most notably, in this release:

--- a/org-roam.el
+++ b/org-roam.el
@@ -246,11 +246,19 @@ it as FILE-PATH."
 
 (defun org-roam--extract-titles ()
   "Extract the titles from current buffer.
-Titles are obtained via the #+TITLE property, or aliases
-specified via the #+ROAM_ALIAS property."
+Titles are obtained via:
+
+1. The #+TITLE property or the first headline
+2. The aliases specified via the #+ROAM_ALIAS property."
   (let* ((props (org-roam--extract-global-props '("TITLE" "ROAM_ALIAS")))
          (aliases (cdr (assoc "ROAM_ALIAS" props)))
-         (title (cdr (assoc "TITLE" props)))
+         (title (or (cdr (assoc "TITLE" props))
+                    (org-element-map
+                        (org-element-parse-buffer)
+                        'headline
+                      (lambda (h)
+                        (org-no-properties (org-element-property :raw-value h)))
+                      :first-match t)))
          (alias-list (org-roam--aliases-str-to-list aliases)))
     (if title
         (cons title alias-list)


### PR DESCRIPTION
###### Motivation for this change

Optionally pulls title from the first headline in Org file. Closes #506.


