### PR TITLE
graph: add an option of wrapping the title

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -99,7 +99,7 @@ Example:
 
 (defcustom org-roam-graph-short-titles t
   "When this is non-nil, truncate titles in graph nodes.
-The title will be trancated according to `org-roam-graph-max-title-length'.
+The title will be truncated according to `org-roam-graph-max-title-length'.
 
 This can also be set to symbol 'wrap, in which case long titles
 will be wrapped with `org-roam-graph-max-title-length' as the

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -97,17 +97,17 @@ Example:
   :type 'number
   :group 'org-roam)
 
-(defcustom org-roam-graph-short-titles t
-  "When this is non-nil, truncate titles in graph nodes.
-The title will be truncated according to `org-roam-graph-max-title-length'.
+(defcustom org-roam-graph-shorten-titles 'truncate
+  "Determines how long titles appear in graph nodes.
+Recognized values are the symbols `truncate' and `wrap', in which
+cases the title will be truncated or wrapped, respectively, if it
+is longer than `org-roam-graph-max-title-length'.
 
-This can also be set to symbol 'wrap, in which case long titles
-will be wrapped with `org-roam-graph-max-title-length' as the
-maximum line width."
+All other values including nil will have no effect."
   :type '(choice
-          (const :tag "Yes" t)
-          (const :tag "Wrap" wrap)
-          (const :tag "No" nil))
+          (const :tag "truncate" truncate)
+          (const :tag "wrap" wrap)
+          (const :tag "no" nil))
   :group 'org-roam)
 
 (defcustom org-roam-graph-exclude-matcher nil
@@ -191,10 +191,10 @@ into a digraph."
         (let* ((file (xml-escape-string (car node)))
                (title (or (caadr node)
                           (org-roam--path-to-slug file)))
-               (shortened-title (pcase org-roam-graph-short-titles
-                                  (`nil title)
-                                  (`wrap  (s-word-wrap org-roam-graph-max-title-length title))
-                                  (_ (s-truncate org-roam-graph-max-title-length title))))
+               (shortened-title (pcase org-roam-graph-shorten-titles
+                                  (`truncate (s-truncate org-roam-graph-max-title-length title))
+                                  (`wrap (s-word-wrap org-roam-graph-max-title-length title))
+                                  (_ title)))
                (node-properties
                 `(("label"   . ,(s-replace "\"" "\\\"" shortened-title))
                   ("URL"     . ,(concat "org-protocol://roam-file?file=" (url-hexify-string file)))

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -97,10 +97,17 @@ Example:
   :type 'number
   :group 'org-roam)
 
-(defcustom org-roam-graph-wrap-title t
-  "When this is non-nil, wrap the title instead of truncating it.
-The value of `org-roam-graph-max-title-length` is used for wrapping."
-  :type 'boolean
+(defcustom org-roam-graph-short-titles t
+  "When this is non-nil, truncate titles in graph nodes.
+The title will be trancated according to `org-roam-graph-max-title-length'.
+
+This can also be set to symbol 'wrap, in which case long titles
+will be wrapped with `org-roam-graph-max-title-length' as the
+maximum line width."
+  :type '(choice
+          (const :tag "Yes" t)
+          (const :tag "Wrap" wrap)
+          (const :tag "No" nil))
   :group 'org-roam)
 
 (defcustom org-roam-graph-exclude-matcher nil
@@ -184,9 +191,10 @@ into a digraph."
         (let* ((file (xml-escape-string (car node)))
                (title (or (caadr node)
                           (org-roam--path-to-slug file)))
-               (shortened-title (or (and org-roam-graph-wrap-title
-                                         (s-word-wrap org-roam-graph-max-title-length title))
-                                    (s-truncate org-roam-graph-max-title-length title)))
+               (shortened-title (pcase org-roam-graph-short-titles
+                                  (`nil title)
+                                  (`wrap  (s-word-wrap org-roam-graph-max-title-length title))
+                                  (_ (s-truncate org-roam-graph-max-title-length title))))
                (node-properties
                 `(("label"   . ,(s-replace "\"" "\\\"" shortened-title))
                   ("URL"     . ,(concat "org-protocol://roam-file?file=" (url-hexify-string file)))

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -97,6 +97,12 @@ Example:
   :type 'number
   :group 'org-roam)
 
+(defcustom org-roam-graph-wrap-title t
+  "When this is non-nil, wrap the title instead of truncating it.
+The value of `org-roam-graph-max-title-length` is used for wrapping."
+  :type 'boolean
+  :group 'org-roam)
+
 (defcustom org-roam-graph-exclude-matcher nil
   "Matcher for excluding nodes from the generated graph.
 Any nodes and links for file paths matching this string is
@@ -178,7 +184,9 @@ into a digraph."
         (let* ((file (xml-escape-string (car node)))
                (title (or (caadr node)
                           (org-roam--path-to-slug file)))
-               (shortened-title (s-truncate org-roam-graph-max-title-length title))
+               (shortened-title (or (and org-roam-graph-wrap-title
+                                         (s-word-wrap org-roam-graph-max-title-length title))
+                                    (s-truncate org-roam-graph-max-title-length title)))
                (node-properties
                 `(("label"   . ,(s-replace "\"" "\\\"" shortened-title))
                   ("URL"     . ,(concat "org-protocol://roam-file?file=" (url-hexify-string file)))


### PR DESCRIPTION
###### Description

Add an option to wrap the title in the graphviz graph instead of truncating it.
The value of `org-roam-graph-max-title-length` will be used for wrapping

###### Motivation for this change
Things will look nicer and no information is lost!