### PR TITLE
(doc): Add key-binding for index in default configs

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -88,7 +88,7 @@ In Org-roam, you can define the path to your index file by setting `org-roam-ind
 (setq org-roam-index-file "index.org")
 ```
 
-You can then bind `org-roam-find-index` in your configuration to access it (see [Basic Install and
+You can then bind `org-roam-jump-to-index` in your configuration to access it (see [Basic Install and
 Configuration](installation.md/#basic-install-and-configuration) to review how
 to set key-bindings).
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -21,7 +21,7 @@ The recommended method of configuration is to use [use-package][use-package].
       :bind (:map org-roam-mode-map
               (("C-c n l" . org-roam)
                ("C-c n f" . org-roam-find-file)
-               ("C-c n j" . org-roam-find-index)
+               ("C-c n j" . org-roam-jump-to-index)
                ("C-c n b" . org-roam-switch-to-buffer)
                ("C-c n g" . org-roam-graph))
               :map org-mode-map
@@ -34,7 +34,7 @@ Or without `use-package`:
 (require 'org-roam)
 (define-key org-roam-mode-map (kbd "C-c n l") #'org-roam)
 (define-key org-roam-mode-map (kbd "C-c n f") #'org-roam-find-file)
-(define-key org-roam-mode-map (kbd "C-c n j") #'org-roam-find-index)
+(define-key org-roam-mode-map (kbd "C-c n j") #'org-roam-jump-to-index)
 (define-key org-roam-mode-map (kbd "C-c n b") #'org-roam-switch-to-buffer)
 (define-key org-roam-mode-map (kbd "C-c n g") #'org-roam-graph)
 (define-key org-mode-map (kbd "C-c n i") #'org-roam-insert)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -21,6 +21,7 @@ The recommended method of configuration is to use [use-package][use-package].
       :bind (:map org-roam-mode-map
               (("C-c n l" . org-roam)
                ("C-c n f" . org-roam-find-file)
+               ("C-c n j" . org-roam-find-index)
                ("C-c n b" . org-roam-switch-to-buffer)
                ("C-c n g" . org-roam-graph))
               :map org-mode-map
@@ -33,6 +34,7 @@ Or without `use-package`:
 (require 'org-roam)
 (define-key org-roam-mode-map (kbd "C-c n l") #'org-roam)
 (define-key org-roam-mode-map (kbd "C-c n f") #'org-roam-find-file)
+(define-key org-roam-mode-map (kbd "C-c n j") #'org-roam-find-index)
 (define-key org-roam-mode-map (kbd "C-c n b") #'org-roam-switch-to-buffer)
 (define-key org-roam-mode-map (kbd "C-c n g") #'org-roam-graph)
 (define-key org-mode-map (kbd "C-c n i") #'org-roam-insert)

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -71,6 +71,8 @@
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam-graph-build 'org-roam-graph
   "org-roam 1.0.0")
+(define-obsolete-function-alias 'org-roam-find-index 'org-roam-jump-to-index
+  "org-roam 1.1.0")
 
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options

--- a/org-roam.el
+++ b/org-roam.el
@@ -502,7 +502,7 @@ which takes as its argument an alist of path-completions.  See
   (interactive)
   (find-file org-roam-directory))
 
-;;;; org-roam-find-index
+;;;; org-roam-jump-to-index
 (defcustom org-roam-index-file nil
   "Path to the Org-roam index file.
 The path can be a string or a function.  If it is a string, it
@@ -533,7 +533,7 @@ whose title is 'Index'."
         (concat (file-truename org-roam-directory) path)
       index)))
 
-(defun org-roam-find-index ()
+(defun org-roam-jump-to-index ()
   "Find the index file in `org-roam-directory'.
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, the function will look in your `org-roam-directory'


### PR DESCRIPTION
I've forgotten to add the new command for finding the index in the default key-bindings.  This will further help the discoverability of the command.

I'm not sure about the key used for the key-binding, though.  I opted for `j` because it's easy to access, and you can kind of remember it like `jump to index`.  If we bring this idea to its logical conclusion, we might want to rename the command to `org-roam-jump-to-index`.