### PR TITLE
Ensure that multicite links are correctly split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#509](https://github.com/jethrokuan/org-roam/pull/509) fix backup files being tracked in database
 * [#509](https://github.com/jethrokuan/org-roam/pull/509) fix external org files being tracked in database
 * [#537](https://github.com/jethrokuan/org-roam/pull/537) quote graphviz node and edge configuration options to allow multi-word configurations
+* [#545](https://github.com/jethrokuan/org-roam/pull/545) fix `org-roam--extract-links` to ensure that multiple citations (`cite:key1,key2`) are split correctly
 
 ### Features
 * [#538](https://github.com/jethrokuan/org-roam/pull/538) Optionally use text in first headline as title 

--- a/org-roam.el
+++ b/org-roam.el
@@ -238,6 +238,14 @@ in temp buffers.  In cases where this occurs, we do know the file path, and pass
 it as FILE-PATH."
   (let ((file-path (or file-path
                        (file-truename (buffer-file-name)))))
+    (mapcan (lambda (linkvec)           ; Split any multi-cite citations
+              (if (string= (aref linkvec 2) "cite")
+                  (mapcar (lambda (ref) (vector (aref linkvec 0)
+                                                ref
+                                                (aref linkvec 2)
+                                                (aref linkvec 3)))
+                          (split-string (aref linkvec 1) ","))
+                (list linkvec)))
     (org-element-map (org-element-parse-buffer) 'link
       (lambda (link)
         (let* ((type (org-element-property :type link))
@@ -270,7 +278,7 @@ it as FILE-PATH."
                             ((string= link-type "cite")
                              path))
                       link-type
-                      (list :content content :point begin)))))))))
+                      (list :content content :point begin))))))))))
 
 (defcustom org-roam-title-include-subdirs nil
   "When non-nil, include subdirs in title completions.

--- a/org-roam.el
+++ b/org-roam.el
@@ -273,12 +273,12 @@ it as FILE-PATH."
                        link-type
                        (list :content content :point begin)))))))
      (mapcan (lambda (linkvec)          ; Split any multi-cite citations
-               (if (string= (aref linkvec 2) "cite")
+               (if (and (string= (aref linkvec 2) "cite") (require 'org-ref nil t))
                    (mapcar (lambda (ref) (vector (aref linkvec 0)
                                                  ref
                                                  (aref linkvec 2)
                                                  (aref linkvec 3)))
-                           (split-string (aref linkvec 1) ","))
+                           (org-ref-split-and-strip-string (aref linkvec 1)))
                  (list linkvec)))))))
 
 (defcustom org-roam-title-include-subdirs nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -265,24 +265,19 @@ it as FILE-PATH."
                    (content (string-trim content))
                    ;; Expand all relative links to absolute links
                    (content (org-roam--expand-links content file-path)))
-              (let ((context (list :content content :point begin)))
-                (pcase link-type
-                  ("roam"
-                   (push (vector file-path
-                                 (file-truename (expand-file-name path (file-name-directory file-path)))
-                                 link-type
-                                 context)
-                         links))
-                  ("cite"
-                   (require 'org-ref nil t)
-                   ;; Separate citekeys and process them individually
-                   (seq-do (lambda (citekey)
-                             (push (vector file-path
-                                           citekey
-                                           link-type
-                                           context)
-                                   links))
-                           (org-ref-split-and-strip-string path))))))))))
+              (let ((context (list :content content :point begin))
+                    (names (pcase link-type
+                             ("roam"
+                              (list (file-truename (expand-file-name path (file-name-directory file-path)))))
+                             ("cite"
+                              (org-ref-split-and-strip-string path)))))
+                (seq-do (lambda (name)
+                          (push (vector file-path
+                                        name
+                                        link-type
+                                        context)
+                                links))
+                        names)))))))
     links))
 
 (defcustom org-roam-title-include-subdirs nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -237,49 +237,53 @@ FILE-FROM is typically the buffer file path, but this may not exist, for example
 in temp buffers.  In cases where this occurs, we do know the file path, and pass
 it as FILE-PATH."
   (let ((file-path (or file-path
-                       (file-truename (buffer-file-name)))))
-    (->>
-     (org-element-map (org-element-parse-buffer) 'link
-       (lambda (link)
-         (let* ((type (org-element-property :type link))
-                (path (org-element-property :path link))
-                (start (org-element-property :begin link))
-                (link-type (cond ((and (string= type "file")
-                                       (org-roam--org-file-p path))
-                                  "roam")
-                                 ((and
-                                   (require 'org-ref nil t)
-                                   (-contains? org-ref-cite-types type))
-                                  "cite")
-                                 (t nil))))
-           (when link-type
-             (goto-char start)
-             (let* ((element (org-element-at-point))
-                    (begin (or (org-element-property :content-begin element)
-                               (org-element-property :begin element)))
-                    (content (or (org-element-property :raw-value element)
-                                 (buffer-substring-no-properties
-                                  begin
-                                  (or (org-element-property :content-end element)
-                                      (org-element-property :end element)))))
-                    (content (string-trim content))
-                    ;; Expand all relative links to absolute links
-                    (content (org-roam--expand-links content file-path)))
-               (vector file-path
-                       (cond ((string= link-type "roam")
-                              (file-truename (expand-file-name path (file-name-directory file-path))))
-                             ((string= link-type "cite")
-                              path))
-                       link-type
-                       (list :content content :point begin)))))))
-     (mapcan (lambda (linkvec)          ; Split any multi-cite citations
-               (if (and (string= (aref linkvec 2) "cite") (require 'org-ref nil t))
-                   (mapcar (lambda (ref) (vector (aref linkvec 0)
-                                                 ref
-                                                 (aref linkvec 2)
-                                                 (aref linkvec 3)))
-                           (org-ref-split-and-strip-string (aref linkvec 1)))
-                 (list linkvec)))))))
+                       (file-truename (buffer-file-name))))
+        links)
+    (org-element-map (org-element-parse-buffer) 'link
+      (lambda (link)
+        (let* ((type (org-element-property :type link))
+               (path (org-element-property :path link))
+               (start (org-element-property :begin link))
+               (link-type (cond ((and (string= type "file")
+                                      (org-roam--org-file-p path))
+                                 "roam")
+                                ((and
+                                  (require 'org-ref nil t)
+                                  (-contains? org-ref-cite-types type))
+                                 "cite")
+                                (t nil))))
+          (when link-type
+            (goto-char start)
+            (let* ((element (org-element-at-point))
+                   (begin (or (org-element-property :content-begin element)
+                              (org-element-property :begin element)))
+                   (content (or (org-element-property :raw-value element)
+                                (buffer-substring-no-properties
+                                 begin
+                                 (or (org-element-property :content-end element)
+                                     (org-element-property :end element)))))
+                   (content (string-trim content))
+                   ;; Expand all relative links to absolute links
+                   (content (org-roam--expand-links content file-path)))
+              (let ((context (list :content content :point begin)))
+                (pcase link-type
+                  ("roam"
+                   (push (vector file-path
+                                 (file-truename (expand-file-name path (file-name-directory file-path)))
+                                 link-type
+                                 context)
+                         links))
+                  ("cite"
+                   (require 'org-ref nil t)
+                   ;; Separate citekeys and process them individually
+                   (seq-do (lambda (citekey)
+                             (push (vector file-path
+                                           citekey
+                                           link-type
+                                           context)
+                                   links))
+                           (org-ref-split-and-strip-string path))))))))))
+    links))
 
 (defcustom org-roam-title-include-subdirs nil
   "When non-nil, include subdirs in title completions.


### PR DESCRIPTION
org-ref multi-citations are handled by "cite:key1,key2". In the org-roam databases this was
previously stored as a single "cite" link to the (non-existing) key "key1,key2". This means that
cite backlinks and cite graph behaviour does not work correctly for these links.

This fix will split any cite links with a comma into separate links to each individual ref.

To be honest, I don't really  like how this patch changes the readability of `org-roam--extract-links`. Because I've basically wrapped the existing code in a `mapccan`, the code to split the multicite links now appears before the code to actually extract the links; in my mind these should be the other way around. In addition, properly indenting would cause a gross diff (I've currently left the original indentation). Not sure how to fix this with my limited emacs-lisp knowledge so suggestions are welcome.

###### Motivation for this change
Fixes #544 
