### PR TITLE
Generate cite backlinks using all org ref cite types

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -115,7 +115,11 @@ When non-nil, the window will not be closed when deleting other windows."
   (if-let* ((roam-key (with-temp-buffer
                         (insert-buffer-substring org-roam-buffer--current)
                         (org-roam--extract-ref)))
-            (key-backlinks (org-roam--get-backlinks (s-chop-prefix "cite:" roam-key)))
+            (org-ref-p (require 'org-ref nil t)) ; Ensure that org-ref is present
+            (cite-prefixes (-map (lambda (type)
+                                   (concat type ":")) org-ref-cite-types))
+            (key-backlinks (org-roam--get-backlinks
+                            (s-chop-prefixes cite-prefixes roam-key)))
             (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
       (progn
         (insert (let ((l (length key-backlinks)))


### PR DESCRIPTION
Generate cite backlinks correctly when the `ROAM_KEY` is a cite-type other than `cite`

This fix would fail on pathological cases where the key itself contains other prefixes e.g. if the key
is `cite:parencite:autocite:key`. Although this is unlikely... Any quick and easy way to only chop the first prefix found? Or is this acceptable?

To use org-ref-cite-types, we must ensure that org-ref is loaded. This would likely already be done
otherwise as the user is obviously using cite links.

###### Motivation for this change
Lots of discussion in https://github.com/jethrokuan/org-roam/issues/540 https://github.com/jethrokuan/org-roam/pull/547 https://github.com/zaeph/org-roam-bibtex/pull/22 https://github.com/zaeph/org-roam-bibtex/pull/21 