### PR TITLE
(feat): add prefix argument to force database rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * [#545](https://github.com/jethrokuan/org-roam/pull/545) fix `org-roam--extract-links` to ensure that multiple citations (`cite:key1,key2`) are split correctly
 
 ### Features
-* [#538](https://github.com/jethrokuan/org-roam/pull/538) Optionally use text in first headline as title 
+* [#538](https://github.com/jethrokuan/org-roam/pull/538) Optionally use text in first headline as title
+* [#553](https://github.com/jethrokuan/org-roam/pull/553) Add prefix argument to `org-roam-db-build-cache` for forcing rebuilds
 
 ## 1.1.0 (21-04-2020)
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -342,9 +342,11 @@ including the file itself.  If the file does not have any connections, nil is re
           (org-roam-db--update-cache-links)
           (org-roam-buffer--update-maybe :redisplay t))))))
 
-(defun org-roam-db-build-cache ()
-  "Build the cache for `org-roam-directory'."
-  (interactive)
+(defun org-roam-db-build-cache (&optional force)
+  "Build the cache for `org-roam-directory'.
+If FORCE, force a rebuild of the cache from scratch."
+  (interactive "P")
+  (when force (delete-file (org-roam-db--get)))
   (org-roam-db--close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
   (let* ((org-roam-files (org-roam--list-all-files))


### PR DESCRIPTION
###### Motivation for this change

Addresses https://github.com/jethrokuan/org-roam/pull/547#issuecomment-623080000

Running `C-u M-x org-roam-db-build-cache` will rebuild the database from scratch.