### PR TITLE
(internal): make lint errors fail CI, and disable spellcheck during linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     # as failures, so linting and testing are run as separate steps.
 
     - name: Lint
-      continue-on-error: true
+      continue-on-error: false
       run: ./makem.sh -vv --sandbox $SANDBOX_DIR lint
 
     - name: Test

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -248,7 +248,7 @@ the default template, reproduced below.
 3. =plain= text is inserted. Other options include Org headings via
    =entry=.
 4. =(function org-roam--capture-get-point)= should not be changed.
-5. ="%?"= is the template inserted on each call to =org-roam--capture=.
+5. ="%?"= is the template inserted on each call to =org-roam-capture--capture=.
    This template means don't insert any content, but place the cursor
    here.
 6. =:file-name= is the file-name template for a new note, if it doesn't

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -422,7 +422,7 @@ The template is given a description of @samp{"default"}.
 @samp{(function org-roam--capture-get-point)} should not be changed.
 
 @item
-@samp{"%?"} is the template inserted on each call to @samp{org-roam--capture}.
+@samp{"%?"} is the template inserted on each call to @samp{org-roam-capture--capture}.
 This template means don't insert any content, but place the cursor
 here.
 

--- a/doc/templating.md
+++ b/doc/templating.md
@@ -28,7 +28,7 @@ additional properties:
 
 Org-roam's template definitions also extend org-capture's template
 syntax, to allow prefilling of strings. In many scenarios,
-`org-roam--capture` is passed a mapping between variables and strings.
+`org-roam-capture--capture` is passed a mapping between variables and strings.
 For example, during `org-roam-insert`, a title is prompted for. If the
 title doesn't already exist, we would like to create a new file,
 without prompting for the title again.
@@ -105,7 +105,7 @@ Here I walkthrough the default template, reproduced below.
 3. `plain` text is inserted. Other options include Org headings via
    `entry`.
 4. `(function org-roam--capture-get-point)` should not be changed.
-5. `"%?"` is the template inserted on each call to `org-roam--capture`.
+5. `"%?"` is the template inserted on each call to `org-roam-capture--capture`.
    This template means don't insert any content, but place the cursor
    here.
 6. `:file-name` is the file-name template for a new note, if it

--- a/makem.sh
+++ b/makem.sh
@@ -155,6 +155,7 @@ function elisp-checkdoc-file {
     (when makem-checkdoc-errors-p
       (kill-emacs 1))))
 
+(setq sentence-end-double-space nil)
 (setq checkdoc-spellcheck-documentation-flag nil)
 (makem-checkdoc-files-and-exit)
 EOF

--- a/makem.sh
+++ b/makem.sh
@@ -326,7 +326,7 @@ function dirnames {
 
 function filter-files-exclude-default {
     # Filter out paths (STDIN) which should be excluded by default.
-    egrep -v "(/\.cask/|-autoloads.el|.dir-locals)"
+    egrep -v "(/\.cask/|-autoloads.el|-macs.el|.dir-locals)"
 }
 
 function filter-files-exclude-args {

--- a/makem.sh
+++ b/makem.sh
@@ -695,7 +695,7 @@ function lint {
     lint-checkdoc
     lint-compile
     lint-declare
-    lint-indent
+    # lint-indent
     lint-package
     lint-regexps
 }

--- a/makem.sh
+++ b/makem.sh
@@ -155,7 +155,7 @@ function elisp-checkdoc-file {
     (when makem-checkdoc-errors-p
       (kill-emacs 1))))
 
-(setq checkdoc-spellcheck-documentation-flag t)
+(setq checkdoc-spellcheck-documentation-flag nil)
 (makem-checkdoc-files-and-exit)
 EOF
     echo $file

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -102,7 +102,7 @@ When non-nil, the window will not be closed when deleting other windows."
                        'font-lock-face
                        'org-document-title)))
 
-(defun org-roam--pluralize (string number)
+(defun org-roam-buffer--pluralize (string number)
   "Conditionally pluralize STRING if NUMBER is above 1."
   (let ((l (pcase number
              ((pred (listp)) (length number))
@@ -126,7 +126,7 @@ When non-nil, the window will not be closed when deleting other windows."
       (progn
         (insert (let ((l (length key-backlinks)))
                   (format "\n\n* %d %s\n"
-                          l (org-roam--pluralize "Cite backlink" l))))
+                          l (org-roam-buffer--pluralize "Cite backlink" l))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))
@@ -152,7 +152,7 @@ When non-nil, the window will not be closed when deleting other windows."
       (progn
         (insert (let ((l (length backlinks)))
                      (format "\n\n* %d %s\n"
-                             l (org-roam--pluralize "Backlink" l))))
+                             l (org-roam-buffer--pluralize "Backlink" l))))
         (dolist (group grouped-backlinks)
           (let ((file-from (car group))
                 (bls (cdr group)))

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -40,6 +40,8 @@
 (defvar org-return-follows-link)
 (defvar org-roam-backlinks-mode)
 (defvar org-roam-last-window)
+(defvar org-ref-cite-types) ;; in org-ref-core.el
+
 (declare-function org-roam-db--ensure-built   "org-roam-db")
 (declare-function org-roam--extract-ref       "org-roam")
 (declare-function org-roam--get-title-or-slug "org-roam")

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -129,9 +129,11 @@ Details on how to specify for the template is given in `org-roam-capture-templat
 (defun org-roam-capture--in-process-p ()
   "Return non-nil if a `org-roam-capture' buffer exists."
   (cl-some (lambda (buffer)
-	     (and (eq (buffer-local-value 'major-mode (current-buffer)) 'org-mode)
-		  (plist-get (buffer-local-value 'org-capture-current-plist (current-buffer)) :org-roam)))
-	   (buffer-list)))
+             (and (eq (buffer-local-value 'major-mode buffer)
+                      'org-mode)
+                  (plist-get (buffer-local-value 'org-capture-current-plist buffer)
+                             :org-roam)))
+           (buffer-list)))
 
 (defun org-roam-capture--fill-template (str &optional info)
   "Expands the template STR, returning the string.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -313,7 +313,7 @@ Suitable for moving point."
   :group 'org-roam
   :type 'hook)
 
-(defun org-roam--capture (&optional goto keys)
+(defun org-roam-capture--capture (&optional goto keys)
   "Create a new file, and return the path to the edited file.
 The templates are defined at `org-roam-capture-templates'.  The
 GOTO and KEYS argument have the same functionality as
@@ -339,7 +339,7 @@ This uses the templates defined at `org-roam-capture-templates'."
                                         (cons 'file file-path)))
           (org-roam-capture--context 'capture))
       (setq org-roam-capture-additional-template-props (list :capture-fn 'org-roam-capture))
-      (org-roam--capture))))
+      (org-roam-capture--capture))))
 
 (provide 'org-roam-capture)
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -85,10 +85,6 @@
   'org-roam-graph-extra-config "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-graph-node-shape
   'org-roam-graph-node-extra-config "org-roam 1.0.0")
-(defcustom org-roam-graph-node-shape "ellipse"
-  "Shape of graph nodes."
-  :type 'string
-  :group 'org-roam)
 (define-obsolete-variable-alias 'org-roam--db-connection
   'org-roam-db--connection "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam--current-buffer

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -73,13 +73,18 @@
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam-find-index 'org-roam-jump-to-index
   "org-roam 1.1.0")
+(define-obsolete-function-alias 'org-roam--pluralize 'org-roam-buffer--pluralize
+  "org-roam 1.1.0")
+(define-obsolete-function-alias 'org-roam--capture 'org-roam-capture--capture
+  "org-roam 1.1.0")
 
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-grapher-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")
-(make-obsolete-variable 'org-roam-graph-node-shape  'org-roam-graph-node-extra-config "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam-graph-node-shape
+  'org-roam-graph-node-extra-config "org-roam 1.0.0")
 (defcustom org-roam-graph-node-shape "ellipse"
   "Shape of graph nodes."
   :type 'string

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -69,7 +69,7 @@ With numeric argument N, use N days in the future."
   "Create and find the file for yesterday.
 With numeric argument N, use N days in the past."
   (interactive "p")
-  (org-roam-tomorrow (- n)))
+  (org-roam-dailies-tomorrow (- n)))
 
 (defun org-roam-dailies-date ()
   "Create the file for any date using the calendar interface."

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -1,4 +1,4 @@
-;;; org-roam-dialies.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t -*-
+;;; org-roam-dailies.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t -*-
 ;;;
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 
@@ -52,7 +52,7 @@
         (org-roam-capture--info (list (cons 'time time)))
         (org-roam-capture--context 'dailies))
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-    (org-roam--capture)))
+    (org-roam-capture--capture)))
 
 (defun org-roam-dailies-today ()
   "Create and find the daily note for today."
@@ -78,4 +78,5 @@ With numeric argument N, use N days in the past."
     (org-roam-dailies--file-for-time time)))
 
 (provide 'org-roam-dailies)
+
 ;;; org-roam-dailies.el ends here

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -39,11 +39,12 @@
 (defvar org-roam-directory)
 (defvar org-roam-verbose)
 
-(declare-function org-roam--extract-titles      "org-roam")
-(declare-function org-roam--extract-ref         "org-roam")
-(declare-function org-roam--extract-links       "org-roam")
-(declare-function org-roam--list-files          "org-roam")
-(declare-function org-roam-buffer--update-maybe "org-roam-buffer")
+(declare-function org-roam--org-roam-file-p                "org-roam")
+(declare-function org-roam--extract-and-format-titles      "org-roam")
+(declare-function org-roam--extract-ref                    "org-roam")
+(declare-function org-roam--extract-links                  "org-roam")
+(declare-function org-roam--list-all-files                 "org-roam")
+(declare-function org-roam-buffer--update-maybe           "org-roam-buffer")
 
 ;;;; Options
 (defcustom org-roam-db-location nil
@@ -270,8 +271,9 @@ If the file does not have any connections, nil is returned."
     files))
 
 (defun org-roam-db--links-with-max-distance (file max-distance)
-  "Return all files reachable from/connected to FILE in at most MAX-DISTANCE steps,
-including the file itself.  If the file does not have any connections, nil is returned."
+  "Return all files connected to FILE in at most MAX-DISTANCE steps.
+This includes the file itself. If the file does not have any
+connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS
                      (WITH roamlinks AS (SELECT * FROM links WHERE \"type\" = '\"roam\"'),

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -62,7 +62,7 @@ It opens or creates a note with the given ref.
            (org-roam-capture--info decoded-alist)
            (template (cdr (assoc 'template decoded-alist))))
       (raise-frame)
-      (org-roam--capture nil template)
+      (org-roam-capture--capture nil template)
       (message "Item captured.")))
   nil)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -458,15 +458,15 @@ which takes as its argument an alist of path-completions.  See
             (delete-region (car region) (cdr region)))
           (insert (org-roam--format-link target-file-path link-description)))
       (when (org-roam-capture--in-process-p)
-	(user-error "Nested Org-roam capture processes not supported"))
+        (user-error "Nested Org-roam capture processes not supported"))
       (let ((org-roam-capture--info (list (cons 'title title)
-					  (cons 'slug (org-roam--title-to-slug title))))
-	    (org-roam-capture--context 'title))
-	(add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
-	(setq org-roam-capture-additional-template-props (list :region region
-							       :link-description link-description
-							       :capture-fn 'org-roam-insert))
-	(org-roam--capture)))))
+                                          (cons 'slug (org-roam--title-to-slug title))))
+            (org-roam-capture--context 'title))
+        (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
+        (setq org-roam-capture-additional-template-props (list :region region
+                                                               :link-description link-description
+                                                               :capture-fn 'org-roam-insert))
+        (org-roam-capture--capture)))))
 
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
@@ -505,7 +505,7 @@ which takes as its argument an alist of path-completions.  See
                                             (cons 'slug (org-roam--title-to-slug title))))
               (org-roam-capture--context 'title))
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-          (org-roam--capture))))))
+          (org-roam-capture--capture))))))
 
 ;;;; org-roam-find-directory
 (defun org-roam-find-directory ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -209,7 +209,8 @@ The search terminates when the first property is encountered."
   "Crawl CONTENT for relative links and expand them.
 PATH should be the root from which to compute the relativity."
   (let ((dir (file-name-directory path))
-        (re org-roam--org-link-file-bracket-re))
+        (re org-roam--org-link-file-bracket-re)
+        link)
     (with-temp-buffer
       (insert content)
       (goto-char (point-min))

--- a/org-roam.el
+++ b/org-roam.el
@@ -56,6 +56,7 @@
 ;; To detect cite: links
 (require 'org-ref nil t)
 (defvar org-ref-cite-types) ;; from org-ref-core.el
+(declare-function 'org-ref-split-and-strip-string "ext:org-ref-utils" (string))
 
 ;;;; Customizable Variables
 (defgroup org-roam nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -56,7 +56,7 @@
 ;; To detect cite: links
 (require 'org-ref nil t)
 (defvar org-ref-cite-types) ;; from org-ref-core.el
-(declare-function 'org-ref-split-and-strip-string "ext:org-ref-utils" (string))
+(declare-function org-ref-split-and-strip-string "ext:org-ref-utils" (string))
 
 ;;;; Customizable Variables
 (defgroup org-roam nil
@@ -407,7 +407,6 @@ current buffer is used."
       (s-downcase slug))))
 
 ;;; Interactive Commands
-;;;; org-roam-insert
 (defun org-roam--format-link-title (title)
   "Return the link title, given the file TITLE."
   (if (functionp org-roam-link-title-format)
@@ -469,7 +468,6 @@ which takes as its argument an alist of path-completions.  See
                                                                :capture-fn 'org-roam-insert))
         (org-roam-capture--capture)))))
 
-;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
   "Return a list of cons pairs for titles to absolute path of Org-roam files."
   (let* ((rows (org-roam-db-query [:select [file titles] :from titles]))
@@ -508,13 +506,11 @@ which takes as its argument an alist of path-completions.  See
           (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
           (org-roam-capture--capture))))))
 
-;;;; org-roam-find-directory
 (defun org-roam-find-directory ()
   "Find and open `org-roam-directory'."
   (interactive)
   (find-file org-roam-directory))
 
-;;;; org-roam-jump-to-index
 (defcustom org-roam-index-file nil
   "Path to the Org-roam index file.
 The path can be a string or a function.  If it is a string, it
@@ -559,7 +555,6 @@ command will offer you to create one."
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
         (org-roam-find-file "Index")))))
 
-;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions ()
   "Return a list of cons pairs for refs to absolute path of Org-roam files."
   (let ((rows (org-roam-db-query [:select [ref file] :from refs])))
@@ -578,7 +573,6 @@ INFO is an alist containing additional information."
                                                         :require-match t))))
     (find-file (cdr (assoc ref completions)))))
 
-;;;; org-roam-switch-to-buffer
 (defun org-roam--get-roam-buffers ()
   "Return a list of buffers that are Org-roam files."
   (--filter (and (with-current-buffer it (derived-mode-p 'org-mode))
@@ -837,10 +831,6 @@ Otherwise, behave as if called interactively."
               (replace-match (format "[[file:%s][\\1]]" relative-path))))
           (org-roam-db--update-file file-from)))
       (org-roam-db--update-file new-path))))
-;;; -
+
 (provide 'org-roam)
 ;;; org-roam.el ends here
-
-;; Local Variables:
-;; outline-regexp: ";;;+ "
-;; End:

--- a/org-roam.el
+++ b/org-roam.el
@@ -42,6 +42,7 @@
 (require 's)
 (require 'f)
 (require 'cl-lib)
+
 ;;;; org-roam features
 (require 'org-roam-compat)
 (require 'org-roam-macs)
@@ -54,6 +55,7 @@
 
 ;; To detect cite: links
 (require 'org-ref nil t)
+(defvar org-ref-cite-types) ;; from org-ref-core.el
 
 ;;;; Customizable Variables
 (defgroup org-roam nil


### PR DESCRIPTION
###### Motivation for this change

Lint errors such as compile errors now often slip past, since they don't cause the CI to fail.