### PR TITLE
(chore): inherit org-roam-link-current from org-link

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -667,7 +667,7 @@ ARG is used to forward interactive calls to
   :group 'org-roam-faces)
 
 (defface org-roam-link-current
-  '((t :inherit org-block))
+  '((t :inherit org-link))
   "Face for Org-roam links pointing to the current buffer."
   :group 'org-roam-faces)
 


### PR DESCRIPTION
###### Motivation for this change

A better default for org-roam-link-current is the original org-link
face, rather than org-block.
