### PR TITLE
(feat): add custom face for links without destinations

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -674,7 +674,7 @@ ARG is used to forward interactive calls to
 (defface org-roam-link-invalid
   '((t :inherit (error org-link)))
   "Face for Org-roam links that are not valid.
-Typically, this face is used for links without a destination."
+This face is used for links without a destination."
   :group 'org-roam-faces)
 
 (defun org-roam--in-buffer-p ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -671,7 +671,7 @@ ARG is used to forward interactive calls to
   "Face for Org-roam links pointing to the current buffer."
   :group 'org-roam-faces)
 
-(defface org-roam-link-without-destination
+(defface org-roam-link-invalid
   '((t :inherit (error org-link)))
   "Face for Org-roam links that points to nowhere."
   :group 'org-roam-faces)
@@ -702,7 +702,7 @@ currently opened Org-roam file in the backlink buffer, or
 `org-roam-link-face' if PATH corresponds to any other Org-roam
 file."
   (cond ((not (file-exists-p path))
-         'org-roam-link-without-destination)
+         'org-roam-link-invalid)
         ((and (org-roam--in-buffer-p)
               (org-roam--backlink-to-current-p))
          'org-roam-link-current)

--- a/org-roam.el
+++ b/org-roam.el
@@ -673,7 +673,8 @@ ARG is used to forward interactive calls to
 
 (defface org-roam-link-invalid
   '((t :inherit (error org-link)))
-  "Face for Org-roam links that points to nowhere."
+  "Face for Org-roam links that are not valid.
+Typically, this face is used for links without a destination."
   :group 'org-roam-faces)
 
 (defun org-roam--in-buffer-p ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -671,6 +671,11 @@ ARG is used to forward interactive calls to
   "Face for Org-roam links pointing to the current buffer."
   :group 'org-roam-faces)
 
+(defface org-roam-link-without-destination
+  '((t :inherit (error org-link)))
+  "Face for Org-roam links that points to nowhere."
+  :group 'org-roam-faces)
+
 (defun org-roam--in-buffer-p ()
   "Return t if in the Org-roam buffer."
   (and (boundp org-roam-backlinks-mode)
@@ -697,7 +702,7 @@ currently opened Org-roam file in the backlink buffer, or
 `org-roam-link-face' if PATH corresponds to any other Org-roam
 file."
   (cond ((not (file-exists-p path))
-         'error)
+         'org-roam-link-without-destination)
         ((and (org-roam--in-buffer-p)
               (org-roam--backlink-to-current-p))
          'org-roam-link-current)


### PR DESCRIPTION
Follow-up to #563.

There's a small oddity going on with the syntax-highlighting of `error` in `emacs-lisp-mode` which formats it as the `symbol-function`, but I think this is just cosmetics:
https://github.com/jethrokuan/org-roam/blob/9ae2984bc7ebaf4c19db78618558c7e28c609ac8/org-roam.el#L675