### PR TITLE
(refactor): org-roam-graph-executable error

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -219,23 +219,21 @@ into a digraph."
 
 (defun org-roam-graph--build (&optional node-query)
   "Generate a graph showing the relations between nodes in NODE-QUERY."
-  (let* ((name org-roam-graph-executable)
-         (exec (ignore-errors (executable-find name))))
-    (unless exec
-      (user-error (concat "Cannot find executable "
-                          (when name
-                            (format "\"%s\" " name))
-                          "to generate the graph.  "
-                          "Please adjust `org-roam-graph-executable'")))
-    (let* ((node-query (or node-query
-                           `[:select [file titles]
-                             :from titles
-                             ,@(org-roam-graph--expand-matcher 'file t)]))
-           (graph (org-roam-graph--dot node-query))
-           (temp-dot (make-temp-file "graph." nil ".dot" graph))
-           (temp-graph (make-temp-file "graph." nil ".svg")))
-      (call-process exec nil 0 nil temp-dot "-Tsvg" "-o" temp-graph)
-      temp-graph)))
+  (unless (stringp org-roam-graph-executable)
+    (user-error "`org-roam-graph-executable' must be a string."))
+  (unless (executable-find org-roam-graph-executable)
+    (user-error "Cannot find executable \"%s\" to generate the graph.
+Please adjust `org-roam-graph-executable'"
+                org-roam-graph-executable))
+  (let* ((node-query (or node-query
+                         `[:select [file titles]
+                                   :from titles
+                                   ,@(org-roam-graph--expand-matcher 'file t)]))
+         (graph      (org-roam-graph--dot node-query))
+         (temp-dot   (make-temp-file "graph." nil ".dot" graph))
+         (temp-graph (make-temp-file "graph." nil ".svg")))
+    (call-process exec nil 0 nil temp-dot "-Tsvg" "-o" temp-graph)
+    temp-graph))
 
 (defun org-roam-graph--open (file)
   "Open FILE using `org-roam-graph-viewer' with `view-file' as a fallback."


### PR DESCRIPTION
Give descriptive error when org-roam-graph-executable is not a string.
Simplify error checking logic in org-roam-graph--build.
