### PR TITLE
(feat): allow org-roam-node-display-template to be a closure

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -60,9 +60,13 @@ field. If it's not specified, the field will be inserted as is,
 i.e. it won't be aligned nor trimmed. If it's an integer, the
 field will be aligned accordingly and all the exceeding
 characters will be trimmed out. If it's \"*\", the field will use
-as many characters as possible and will be aligned accordingly."
+as many characters as possible and will be aligned accordingly.
+
+A closure can also be assigned to this variable in which case the
+closure is evaluated and the return value is used as the
+template. The closure must evaluate to a valid template string."
   :group 'org-roam
-  :type  'string)
+  :type  '(string function))
 
 (defcustom org-roam-node-annotation-function #'org-roam-node-read--annotation
   "This function used to attach annotations for `org-roam-node-read'.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -129,7 +129,9 @@ value (possibly nil). Adapted from `s-format'."
                             (funcall replacer var default-val))))
                    (if v (format "%s" v) (signal 'org-roam-format-resolve md)))
                (set-match-data replacer-match-data))))
-         template
+         (if (functionp template)
+             (funcall template)
+           template)
          ;; Need literal to make sure it works
          t t)
       (set-match-data saved-match-data))))


### PR DESCRIPTION
###### Motivation for this change

This PR permits the use of a closure (in addition to a string) as the value of `org-roam-node-display-template`. Using a closure allows context-aware templates and is somewhat more flexible than the current behavior.

One example of a use case is the one I'm employing currently, which calculates field widths based on the current window width:

```elisp
(setq org-roam-node-display-template
      (lambda ()
        (let ((tags-width 25))
          (concat "${outline:"
                  (number-to-string (- (window-width) tags-width 1))
                  "} ${tags:"
                  (number-to-string tags-width)
                  "}"))))
```

(`outline` references my own `cl-defmethod`)

Please let me know if you have any questions/concerns/etc.