### PR TITLE
(chore)libraries: s/s-join/string-join/g

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -272,15 +272,15 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 (defun org-roam--list-files-find (executable dir)
   "Return all Org-roam files under DIR, using \"find\", provided as EXECUTABLE."
   (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (names (s-join " -o " (mapcar (lambda (glob) (concat "-name " glob)) globs)))
-         (command (s-join " " `(,executable "-L" ,dir "-type f \\(" ,names "\\)"))))
+         (names (string-join (mapcar (lambda (glob) (concat "-name " glob)) globs) " -o "))
+         (command (string-join `(,executable "-L" ,dir "-type f \\(" ,names "\\)") " ")))
     (org-roam--shell-command-files command)))
 
 (defun org-roam--list-files-fd (executable dir)
   "Return all Org-roam files under DIR, using \"fd\", provided as EXECUTABLE."
   (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (extensions (s-join " -e " (mapcar (lambda (glob) (substring glob 2 -1)) globs)))
-         (command (s-join " " `(,executable "-L" ,dir "--type file" ,extensions))))
+         (extensions (string-join (mapcar (lambda (glob) (substring glob 2 -1)) globs) " -e "))
+         (command (string-join `(,executable "-L" ,dir "--type file" ,extensions) " ")))
     (org-roam--shell-command-files command)))
 
 (defalias 'org-roam--list-files-fdfind #'org-roam--list-files-fd)
@@ -288,8 +288,8 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 (defun org-roam--list-files-rg (executable dir)
   "Return all Org-roam files under DIR, using \"rg\", provided as EXECUTABLE."
   (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (command (s-join " " `(,executable "-L" ,dir "--files"
-                                            ,@(mapcar (lambda (glob) (concat "-g " glob)) globs)))))
+         (command (string-join `(,executable "-L" ,dir "--files"
+                                             ,@(mapcar (lambda (glob) (concat "-g " glob)) globs)) " ")))
     (org-roam--shell-command-files command)))
 
 (defun org-roam--list-files-elisp (dir)


### PR DESCRIPTION
###### Motivation for this change

Remove usages of s-join. s.el is currently pulled in implicitly by f.el. Related to #1889 .