### PR TITLE
Don't require (probably non-existent) 'oc feature for each org file

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -534,7 +534,8 @@ If the file exists, update the cache with information."
             (setq info (org-element-parse-buffer))
             (org-roam-db-map-links
              (list #'org-roam-db-insert-link))
-            (when (require 'oc nil 'noerror)
+            (when (fboundp 'org-cite-insert)
+              (require 'oc)             ;ensure feature is loaded
               (org-roam-db-map-citations
                info
                (list #'org-roam-db-insert-citation)))))))))


### PR DESCRIPTION
Instead check if the (autoloaded) function `org-cite-insert' is bound.

This prevents a lot of unnecessary filesystem I/O when generating the
org roam database.

###### Motivation for this change

Failing loads for each org file:

```
sudo /usr/share/bcc/tools/opensnoop -n emacs 
....
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emulation/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emulation/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emulation/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emulation/oc.so.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.elc
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.elc.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/emacs-lisp/oc.so.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.elc
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.elc.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/cedet/oc.so.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.elc
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.elc.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calendar/oc.so.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.elc
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.elc.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/calc/oc.so.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.elc
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.elc.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.el
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.el.gz
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.so
24400  emacs              -1   2 /usr/share/emacs/27.2/lisp/obsolete/oc.so.gz

```

Improves performance from:
```
ELISP> (benchmark 1 '(org-roam-db-sync t))
"Elapsed time: 71.088124s (14.771579s in 252 GCs)"
```
to:
```
ELISP> (benchmark 1 '(org-roam-db-sync t))
"Elapsed` time: 64.970797s (14.251655s in 235 GCs)"
```