### PR TITLE
`org-roam-refile`: Don't try to refile a node into itself

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -828,7 +828,7 @@ If region is active, then use it instead of the node at point."
                    (find-file-noselect file)))
          level reversed)
     (if (equal (org-roam-node-at-point) node)
-        (user-error "Target is the same as current node.")
+        (user-error "Target is the same as current node")
       (if regionp
           (progn
             (org-kill-new (buffer-substring region-start region-end))


### PR DESCRIPTION
###### Motivation for this change
Quick fix for #1731. Simply stops the entire operation and notifies the user if the target node is identical to the node at point.