### PR TITLE
(fix) Replace olp with heading list

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -612,13 +612,14 @@ you can catch it with `condition-case'."
          (lmax 1)
          (start (point-min))
          (end (point-max))
+         headings
          found flevel)
     (unless (derived-mode-p 'org-mode)
       (error "Buffer %s needs to be in Org mode" (current-buffer)))
     (org-with-wide-buffer
+     (setq headings (mapcar #'org-roam-capture--fill-template olp))
      (goto-char start)
-     (dolist (heading olp)
-       (setq heading (org-roam-capture--fill-template heading))
+     (dolist (heading headings)
        (let ((re (format org-complex-heading-regexp-format
                          (regexp-quote heading)))
              (cnt 0))

--- a/tests/test-org-roam-dailies.el
+++ b/tests/test-org-roam-dailies.el
@@ -1,0 +1,55 @@
+;;; test-org-roam-dailies.el --- NONDESCRIPT FILE  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Martin Edström
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Code:
+
+(require 'buttercup)
+(require 'org-roam)
+(require 'org-roam-dailies)
+
+;; This is indirectly a test of func `org-roam-capture-find-or-create-olp'
+;; from org-roam-capture.el.
+(describe "org-roam-capture-find-or-create-olp"
+  (before-all
+    (setq org-roam-directory (expand-file-name "tests/roam-files")
+          org-roam-dailies-directory "dailies/"
+          ;; Remember to clean up dailies/test.org lest it break other tests!
+          org-roam-dailies-capture-templates
+          `(("t" "Tasks" entry "* %?"
+             :target (file+head+olp "test.org" ;; "%<%Y-%m-%d>.org"
+                                    "* Notes\n\n* Tasks\n\n* Journal"
+                                    ("Tasks" "[2023-03-28 Tue]")))))
+    (org-roam-db-sync))
+
+  (it "does not create Tasks heading multiple times (issue #2335)"
+    (let (buf)
+      (dotimes (_ 3)
+        (save-window-excursion
+          (setq buf (current-buffer))
+          (org-roam-dailies--capture (current-time) t "t")))
+      (with-current-buffer buf
+        (widen)
+        (goto-char (point-min))
+        (expect (cl-loop while (search-forward "\n* Tasks" nil t) count t)
+                :to-equal 1)
+        (kill-buffer))
+      (delete-file "tests/roam-files/dailies/test.org"))))
+
+(provide 'test-org-roam-dailies)
+
+;;; test-org-roam-dailies.el ends here


### PR DESCRIPTION
###### Motivation for this change
Closes #2335

After `org-roam-capture--fill-template` which actually calls `(kill-buffer)` inside it, strangely `kill-buffer` reverts buffer position from `(point-min)` to original. So `re-search-forward` loop can't find headings correct and `org-roam-capture-find-or-create-olp` keep creating headings if the buffer is already visited and buffer position is under below the OLP.

So I change `olp` to `(setq headings (mapcar #'org-roam-capture--fill-template olp))` then use it in the search loop.

After this patch, below test code doesn't make new "Tasks" heading again when it exists already.
```
(let ((org-roam-directory (expand-file-name org-roam-dailies-directory org-roam-directory))
      (org-roam-dailies-directory "./")
      (org-roam-dailies-capture-templates
       `(("t" "Tasks" entry "* %?"
          :if-new (file+head+olp "test.org" ;; "%<%Y-%m-%d>.org"
                                 "* Notes\n\n* Tasks\n\n* Journal"
                                 ("Tasks" "[2023-03-28 Tue]"))))))
  (save-window-excursion
    (org-roam-dailies--capture (current-time) t)))
```