### PR TITLE
Fix outline path position for org-roam-ref capture

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -673,11 +673,11 @@ the current value of `point'."
                                   '(drawer property-drawer keyword comment comment-block horizontal-rule)))
                   (goto-char (org-element-property :end el))
                   (setq el (org-element-at-point))))
-            (goto-char (org-entry-end-position))))
+            (goto-char (save-excursion (org-end-of-subtree t t) (point)))))
          (heading-at-point
           (if (org-capture-get :prepend)
               (org-end-of-meta-data t)
-            (goto-char (org-entry-end-position))))))))
+            (goto-char (save-excursion (org-end-of-subtree t t) (point)))))))))
   (point))
 
 ;;; Capture implementation
@@ -688,7 +688,11 @@ the current value of `point'."
                         (org-roam-node-from-ref
                          (plist-get org-roam-capture--info :ref)))))
     (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
-    (goto-char (org-roam-node-point node))
+    (let* ((target (org-roam-capture--get-target))
+           (entry (car target)))
+      (if (or (eq 'file+olp entry) (eq 'file+head+olp entry))
+            (goto-char (org-roam-capture-find-or-create-olp (car (last target))))
+        (goto-char (org-roam-node-point node))))
     (widen)
     (org-roam-node-id node)))
 


### PR DESCRIPTION
###### Motivation for this change
Closes #2199 

This PR needs PR #2336 to search correct OLP.

`org-roam-ref-capture` doesn't find correct the outline path when `org-roam-capture--try-capture-to-ref-h` is called. It needs to check `...+olp` and `goto-char` to the OLP directly.

I think `org-entry-end-position` is not work when `:prepend` is nil, which means `append` actually. Because `org-entry-end-position` give you just end (before its subtree) of current entry instead of end of current whole entry including its subtree. That worked as `prepend`  even if `:prepend` is nil.
