### PR TITLE
(feat)capture: add customizable defaults for deleting aborted files

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -343,6 +343,24 @@ The hooks must not move the point."
   :group 'org-roam
   :type 'hook)
 
+(defcustom org-roam-capture-delete-aborted-files 'ask
+  "What to do when a new capture is aborted.
+When running `org-capture-kill':
+- if `ask' (the default) ask whether to delete the new file.
+- if t always delete the file
+- if nil never delete
+- any other value is called as a function and should return one of the
+  above values.
+
+Internally, this functionality is controlled by the function
+`org-roam-capture--check-aborted-delete'."
+  :group 'org-roam
+  :type '(choice
+          (const :tag "Ask whether to delete the new file" ask)
+          (const :tag "Always delete the file" t)
+          (const :tag "Never delete the file" nil)
+          (function :tag "Call with no arguments to get one of the above values")))
+
 (defvar org-roam-capture-preface-hook nil
   "Hook run when Org-roam tries to determine capture location of the node.
 If any hook returns a value (which should be an ID), all hooks
@@ -705,13 +723,21 @@ the current value of `point'."
   (when (org-roam-capture-p)
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--finalize)))
 
+(defun org-roam-capture--check-aborted-delete ()
+  "Return non-nil if aborted captures' files should be deleted."
+  (pcase org-roam-capture-delete-aborted-files
+    ('ask (yes-or-no-p "Delete file for aborted capture?"))
+    ('nil nil)
+    ('t t)
+    (_ (funcall org-roam-capture-delete-aborted-files))))
+
 (defun org-roam-capture--finalize ()
   "Finalize the `org-roam-capture' process."
   (when-let ((region (org-roam-capture--get :region)))
     (org-roam-unshield-region (car region) (cdr region)))
   (if org-note-abort
       (when-let ((new-file (org-roam-capture--get :new-file))
-                 (_ (yes-or-no-p "Delete file for aborted capture?")))
+                 (_ (org-roam-capture--check-aborted-delete)))
         (when (find-buffer-visiting new-file)
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))


### PR DESCRIPTION
* org-roam-capture.el (org-roam-capture-delete-aborted-files): new
custom var
(org-roam-capture--check-aborted-delete): util function to check
whether we should delete the file after an aborted capture.
(org-roam-capture--finalize): use
`org-roam-capture--check-aborted-delete' rather than `yes-or-no-p'.

-------

###### Motivation for this change

I abort captures pretty regularly but I always answer the same to the prompt which asks whether I want to delete the aborted file -- I always want to delete it. This is a (tiny) friction which could be easily customised away. This PR makes that possible.