### PR TITLE
Limit link replacement scope

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -167,6 +167,10 @@ This path is relative to `org-roam-directory'."
   :group 'org-roam
   :type 'string)
 
+(defvar org-roam-link-type "roam"
+  "Link type for org-roam nodes.
+Replaced by `id' automatically when `org-roam-link-auto-replace' is non-nil.")
+
 (defvar org-roam-node-history nil
   "Minibuffer history of nodes.")
 
@@ -768,7 +772,7 @@ The INFO, if provided, is passed to the underlying `org-roam-capture-'."
     (deactivate-mark)))
 
 ;;;;; [roam:] link
-(org-link-set-parameters "roam" :follow #'org-roam-link-follow-link)
+(org-link-set-parameters org-roam-link-type :follow #'org-roam-link-follow-link)
 (defun org-roam-link-follow-link (title-or-alias)
   "Navigate \"roam:\" link to find and open the node with TITLE-OR-ALIAS.
 Assumes that the cursor was put where the link is."
@@ -797,7 +801,7 @@ Assumes that the cursor was put where the link is."
              node)
         (goto-char (org-element-property :begin link))
         (when (and (org-in-regexp org-link-any-re 1)
-                   (string-equal type "roam")
+                   (string-equal type org-roam-link-type)
                    (setq node (save-match-data (org-roam-node-from-title-or-alias path))))
           (replace-match (org-link-make-string
                           (concat "id:" (org-roam-node-id node))
@@ -806,9 +810,10 @@ Assumes that the cursor was put where the link is."
 (defun org-roam-link-replace-all ()
   "Replace all \"roam:\" links in buffer with \"id:\" links."
   (interactive)
-  (org-with-point-at 1
-    (while (re-search-forward org-link-bracket-re nil t)
-      (org-roam-link-replace-at-point))))
+  (let ((org-roam-link-prefix (concat "[[" org-roam-link-type ":")))
+    (org-with-point-at 1
+      (while (re-search-forward org-roam-link-prefix nil t)
+        (org-roam-link-replace-at-point)))))
 
 (add-hook 'org-roam-find-file-hook #'org-roam--replace-roam-links-on-save-h)
 (defun org-roam--replace-roam-links-on-save-h ()


### PR DESCRIPTION
Speeds up link replacement by limiting the scope of `org-roam-link-replace-all` to only `roam:` links.

Fixes #2436.

###### Motivation for this change

See #2436.