### PR TITLE
org-roam-db-insert-aliases clear link with org-link-display-format 

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -503,7 +503,8 @@ INFO is the org-element parsed buffer."
   "Insert aliases for node at point into Org-roam cache."
   (when-let* ((node-id (org-id-get))
               (aliases (org-entry-get (point) "ROAM_ALIASES"))
-              (aliases (split-string-and-unquote aliases)))
+              (aliases (split-string-and-unquote aliases))
+              (aliases (mapcar #'org-link-display-format aliases)))
     (org-roam-db-query [:insert :into aliases
                         :values $v1]
                        (mapcar (lambda (alias)


### PR DESCRIPTION
(Like the title)

###### Motivation for this change

Not have this type of things during the search when having the alias in org-roam-node-display-template :
A nice alias with a [[id:54819299][description of a link]]

Instead, we want this :
A nice alias with a description of a link


