### PR TITLE
(fix): Use correct type specifications to suppress warnings

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -90,7 +90,7 @@ following function shows the title and base filename of the node:
 
 \q(setq org-roam-node-display-template 'my--org-roam-format)"
   :group 'org-roam
-  :type  '(string function))
+  :type  '(choice string function))
 
 (defcustom org-roam-node-annotation-function #'org-roam-node-read--annotation
   "This function used to attach annotations for `org-roam-node-read'.
@@ -114,7 +114,7 @@ argument, an `org-roam-node', and return a string.
 If a string is provided, it is a template string expanded by
 `org-roam-node--format-entry'."
   :group 'org-roam
-  :type '(string function))
+  :type '(choice string function))
 
 (defcustom org-roam-node-template-prefixes
   '(("tags" . "#")


### PR DESCRIPTION
###### Motivation for this change

A recent commit (https://github.com/org-roam/org-roam/commit/fed577f8053db35e822c6458ae63c860494350c8)  introduced a welcome feature of allowing the custom variable `org-roam-node-display-template` to take a function in addition to a string. A minor syntax issue in the :type option leads to a few extra warnings, which this PR fixes.

This PR simply fix the :type options such that custom variables taking either string or function is properly indicated as such, using `choice`.