### PR TITLE
Fix link replacement optimization

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -810,10 +810,9 @@ Assumes that the cursor was put where the link is."
 (defun org-roam-link-replace-all ()
   "Replace all \"roam:\" links in buffer with \"id:\" links."
   (interactive)
-  (let ((org-roam-link-prefix (concat "[[" org-roam-link-type ":")))
-    (org-with-point-at 1
-      (while (re-search-forward org-roam-link-prefix nil t)
-        (org-roam-link-replace-at-point)))))
+  (org-with-point-at 1
+    (while (search-forward (concat "[[" org-roam-link-type ":") nil t)
+      (org-roam-link-replace-at-point))))
 
 (add-hook 'org-roam-find-file-hook #'org-roam--replace-roam-links-on-save-h)
 (defun org-roam--replace-roam-links-on-save-h ()


### PR DESCRIPTION
We are searching for a string literal for speed, so don’t treat it as a regexp.

Fixes: fc8638759b9d ("feat: Limit link replacement scope")
Fixes: #2529

###### Motivation for this change
