### PR TITLE
refactor: remove org-roam-require

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -559,7 +559,7 @@ INFO is the org-element parsed buffer."
     (secure-hash 'sha1 (current-buffer))))
 
 ;;;; Synchronization
-(defun org-roam-db-update-file (&optional file-path no-require)
+(defun org-roam-db-update-file (&optional file-path _deprecated-arg)
   "Update Org-roam cache for FILE-PATH.
 
 If the file does not exist anymore, remove it from the cache.
@@ -575,8 +575,7 @@ in `org-roam-db-sync'."
                                            :where (= file $s1)] file-path)))
         info)
     (unless (string= content-hash db-hash)
-      (unless no-require
-        (org-roam-require '(org-ref oc)))
+      (require 'org-ref nil t)
       (org-roam-with-file file-path nil
         (emacsql-with-transaction (org-roam-db)
           (org-with-wide-buffer
@@ -596,8 +595,7 @@ in `org-roam-db-sync'."
            (setq info (org-element-parse-buffer))
            (org-roam-db-map-links
             (list #'org-roam-db-insert-link))
-           (when (fboundp 'org-cite-insert)
-             (require 'oc)             ;ensure feature is loaded
+           (when (require 'oc nil t)
              (org-roam-db-map-citations
               info
               (list #'org-roam-db-insert-citation)))))))))
@@ -610,7 +608,8 @@ If FORCE, force a rebuild of the cache from scratch."
   (org-roam-db--close) ;; Force a reconnect
   (when force (delete-file org-roam-db-location))
   (org-roam-db) ;; To initialize the database, no-op if already initialized
-  (org-roam-require '(org-ref oc))
+  (require 'org-ref nil t)
+  (require 'oc nil t)
   (let* ((gc-cons-threshold org-roam-db-gc-threshold)
          (org-agenda-files nil)
          (org-roam-files (org-roam-list-files))
@@ -629,7 +628,7 @@ If FORCE, force a rebuild of the cache from scratch."
       (org-roam-dolist-with-progress (file modified-files)
           "Processing modified files..."
         (condition-case err
-            (org-roam-db-update-file file 'no-require)
+            (org-roam-db-update-file file)
           (error
            (org-roam-db-clear-file file)
            (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -34,11 +34,6 @@
 
 (require 'org-roam)
 
-(defun org-roam-require (libs)
-  "Require LIBS."
-  (dolist (lib libs)
-    (require lib nil 'noerror)))
-
 ;;; String utilities
 ;; TODO Refactor this.
 (defun org-roam-replace-string (old new s)


### PR DESCRIPTION
###### Motivation for this change

<!-- Message of single commit: -->

This was always a unnecessary utility.

I'd guess it was written under the misunderstanding that `require`
behaves like `load`, causing a re-load every time it is called.  
In fact, it no-ops if the feature is already loaded.

Let's switch back to plain `require` more familiar to all readers.