### PR TITLE
build: add compat.el

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (compat "30.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -76,6 +76,8 @@
 (require 'rx)
 (require 'seq)
 (require 'cl-lib)
+
+(require 'compat)
 
 (require 'magit-section)
 


### PR DESCRIPTION
###### Motivation for this change

PR https://github.com/org-roam/org-roam/pull/2546 uses `ensure-list`, which came with Emacs 28.

A backport for that (and many other nice things) are in compat.el, so unless we bump the minimum Emacs version, let's just depend on compat and minimize toil.

This is a uncontroversial library, a stub of it is even part of Emacs from Emacs 30 onwards.

Bonus: we'll be able to get rid of `org-roam-dolist-with-progress` in favor of `dolist-with-progress-reporter`.