### PR TITLE
refactor: remove org-roam-dolist-with-progress

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -233,6 +233,10 @@ nodes." org-id-locations-file)
   'org-roam-mode-section-functions
   'org-roam-mode-sections "org-roam 2.2.0")
 
+(define-obsolete-function-alias
+  'org-roam-dolist-with-progress
+  'dolist-with-progress-reporter "2025-11-07")
+
 ;;; Obsolete functions
 (make-obsolete 'org-roam-get-keyword 'org-collect-keywords "org-roam 2.0")
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -623,10 +623,10 @@ If FORCE, force a rebuild of the cache from scratch."
           (push file modified-files)))
       (remhash file current-files))
     (emacsql-with-transaction (org-roam-db)
-      (org-roam-dolist-with-progress (file (hash-table-keys current-files))
+      (dolist-with-progress-reporter (file (hash-table-keys current-files))
           "Clearing removed files..."
         (org-roam-db-clear-file file))
-      (org-roam-dolist-with-progress (file modified-files)
+      (dolist-with-progress-reporter (file modified-files)
           "Processing modified files..."
         (condition-case err
             (org-roam-db-update-file file 'no-require)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -100,23 +100,6 @@ FN must take two arguments: the key and the value."
               plist-index (cdr plist-index)))))
   plist)
 
-(defmacro org-roam-dolist-with-progress (spec msg &rest body)
-  "Loop over a list and report progress in the echo area.
-Like `dolist-with-progress-reporter', but falls back to `dolist'
-if the function does not yet exist.
-
-Evaluate BODY with VAR bound to each car from LIST, in turn.
-Then evaluate RESULT to get return value, default nil.
-
-MSG is a progress reporter object or a string.  In the latter
-case, use this string to create a progress reporter.
-
-SPEC is a list, as per `dolist'."
-  (declare (indent 2))
-  (if (fboundp 'dolist-with-progress-reporter)
-      `(dolist-with-progress-reporter ,spec ,msg ,@body)
-    `(dolist ,spec ,@body)))
-
 ;;; File utilities
 (defun org-roam-descendant-of-p (a b)
   "Return t if A is descendant of B."


### PR DESCRIPTION
###### Motivation for this change

<!-- Message of single commit: -->

refactor: remove org-roam-dolist-with-progress

Even on Emacs 26, compat.el will provide `dolist-with-progress-reporter`.