### PR TITLE
style: remove unnecessary headers in non-main file

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-log.el
+++ b/org-roam-log.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2022-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (magit-section "3.0.0"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -2,12 +2,6 @@
 
 ;; Copyright © 2020-2025 Jethro Kuan <jethrokuan95@gmail.com>
 
-;; Author: Jethro Kuan <jethrokuan95@gmail.com>
-;; URL: https://github.com/org-roam/org-roam
-;; Keywords: org-mode, roam, convenience
-;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6"))
-
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
###### Motivation for this change

<!-- Message of single commit: -->

style: remove unnecessary headers in non-main file

It is not intended to have these kinds of comments other than in the
main file.

Package managers only look at the comments in org-roam.el.