### PR TITLE
fix: don't tag-complete to special keywords in org-tag-alist

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -1113,13 +1113,7 @@ and when nil is returned the node will be filtered out."
 (defun org-roam-tag-completions ()
   "Return list of tags for completions within Org-roam."
   (let ((roam-tags (mapcar #'car (org-roam-db-query [:select :distinct [tag] :from tags])))
-        (org-tags (cl-loop for tagg in org-tag-alist
-                           nconc (pcase tagg
-                                   ('(:newline)
-                                    nil)
-                                   (`(,tag . ,_)
-                                    (list tag))
-                                   (_ nil)))))
+        (org-tags (seq-filter #'stringp (mapcar #'car org-tag-alist))))
     (seq-uniq (append roam-tags org-tags))))
 
 ;;;; Editing

--- a/tests/test-org-roam-node.el
+++ b/tests/test-org-roam-node.el
@@ -279,18 +279,17 @@
                  (org-roam-tag-completions)
                  :test 'equal)))
 
-  ;; ;; FIXME: Currently failing due to defect in `org-roam-tag-completions'
-  ;; (it "skips SPECIAL values in org-tag-alist"
-  ;;   (should-not (member :startgroup (org-roam-tag-completions)))
-  ;;   (should-not (member ":startgroup" (org-roam-tag-completions)))
-  ;;   (should-not (member :endgroup (org-roam-tag-completions)))
-  ;;   (should-not (member ":endgroup" (org-roam-tag-completions))))
+  (it "skips SPECIAL values in org-tag-alist"
+    (should-not (member :startgroup (org-roam-tag-completions)))
+    (should-not (member ":startgroup" (org-roam-tag-completions)))
+    (should-not (member :endgroup (org-roam-tag-completions)))
+    (should-not (member ":endgroup" (org-roam-tag-completions))))
 
   (it "has tags that are only in org-tag-alist"
-      (should
-       (cl-subsetp '("@work" "@home" "@tennisclub" "laptop" "pc")
-                   (org-roam-tag-completions)
-                   :test 'equal))))
+    (should
+     (cl-subsetp '("@work" "@home" "@tennisclub" "laptop" "pc")
+                 (org-roam-tag-completions)
+                 :test 'equal))))
 
 (describe "org-roam CAPFs"
   (before-all


### PR DESCRIPTION
###### Motivation for this change

The current definition only filters out `:newline`. 

But as documentation of `org-tag-alist` shows, there are other SPECIAL keywords than that, such as `:startgroup` and `:endgroup`.  These are definitely not desirable completion candidates in a command like `org-roam-tag-add`.

Fixes: https://github.com/org-roam/org-roam/issues/2477