### PR TITLE
test: fix buttercup warnings

### DIFF
--- a/tests/test-org-roam-capture.el
+++ b/tests/test-org-roam-capture.el
@@ -124,13 +124,9 @@
         (delete-directory temp-dir t)))))
 
 (describe "org-roam-capture advice functions"
-  :var ((org-roam-capture--info))
-
-  (before-each
-    (setq org-roam-capture--info (make-hash-table :test 'equal)))
-
   (it "org-roam-capture--create-id-for-entry creates and removes advice"
     (cl-letf* ((entry-id nil)
+               (org-roam-capture--info (make-hash-table :test 'equal))
                ((symbol-function 'org-entry-put)
                 (lambda (pom prop val)
                   (when (string= prop "ID")
@@ -155,6 +151,7 @@
 
   (it "org-roam-capture--set-target-entry-p-a sets and removes advice"
     (cl-letf* ((captured-value nil)
+               (org-roam-capture--info (make-hash-table :test 'equal))
                ((symbol-function 'org-capture-put)
                 (lambda (prop val)
                   (when (eq prop :target-entry-p)
@@ -270,7 +267,15 @@
         (delete-directory temp-dir t)))))
 
 (describe "org-roam-capture plain type ordering"
-  :var ((temp-dir) (org-roam-directory) (org-roam-db-location))
+  :var (temp-dir original-roam-directory original-roam-db-location)
+
+  (before-all
+    (setq original-roam-directory   org-roam-directory)
+    (setq original-roam-db-location org-roam-db-location))
+
+  (after-all
+    (setq org-roam-directory   original-roam-directory)
+    (setq org-roam-db-location original-roam-db-location))
 
   (before-each
     (setq temp-dir (make-temp-file "org-roam-test" t))


### PR DESCRIPTION
###### Motivation for this change

This fixes the following buttercup warnings seen in every workflow run.  Example taken from 
from https://github.com/org-roam/org-roam/pull/2558/checks:

```
[00:02.556]  Warning (buttercup-describe): Possible erroneous use of special variable `org-roam-capture--info' in :var(*) form
[00:02.557]  Warning (buttercup-describe): Possible erroneous use of special variable `org-roam-directory' in :var(*) form
[00:02.557]  Warning (buttercup-describe): Possible erroneous use of special variable `org-roam-db-location' in :var(*) form
```

To be clear, the tests pass anyway. *Presumably* there was no breakage, but it's ugly and may make PR-submitters follow a wild goose chase, when their tests fail for other reasons.