### PR TITLE
style: obey emacs 31 if-let style to prevent noisy compile messages

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -281,10 +281,10 @@ EXTRA-FILES can be used to append extra files to the list."
 (defun org-roam-dailies--daily-note-p (&optional file)
   "Return t if FILE is an Org-roam daily-note, nil otherwise.
 If FILE is not specified, use the current buffer's file-path."
-  (when-let ((path (expand-file-name
-                    (or file
-                        (buffer-file-name (buffer-base-buffer)))))
-             (directory (expand-file-name org-roam-dailies-directory org-roam-directory)))
+  (when-let* ((path (expand-file-name
+                     (or file
+                         (buffer-file-name (buffer-base-buffer)))))
+              (directory (expand-file-name org-roam-dailies-directory org-roam-directory)))
     (setq path (expand-file-name path))
     (save-match-data
       (and

--- a/extensions/org-roam-export.el
+++ b/extensions/org-roam-export.el
@@ -53,7 +53,7 @@ See `org-html--reference' for DATUM, INFO and NAMED-ONLY."
            datum))
          (user-label
           (or user-label
-              (when-let ((path (org-element-property :ID datum)))
+              (when-let* ((path (org-element-property :ID datum)))
                 ;; see `org-html-link' for why we use "ID-"
                 ;; (search for "ID-" in ox-html.el)
                 (concat "ID-" path)))))

--- a/extensions/org-roam-protocol.el
+++ b/extensions/org-roam-protocol.el
@@ -159,7 +159,7 @@ It should contain the FILE key, pointing to the path of the file to open.
   Example protocol string:
 
 org-protocol://roam-node?node=uuid"
-  (when-let ((node (plist-get info :node)))
+  (when-let* ((node (plist-get info :node)))
     (raise-frame)
     (org-roam-node-visit (org-roam-populate (org-roam-node-create :id node)) nil 'force))
   nil)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -460,7 +460,7 @@ processing by `org-capture'.
 Note: During the capture process this function is run by
 `org-capture-set-target-location', as a (function ...) based
 capture target."
-  (if-let ((id (run-hook-with-args-until-success 'org-roam-capture-preface-hook)))
+  (if-let* ((id (run-hook-with-args-until-success 'org-roam-capture-preface-hook)))
       (org-roam-capture--put :id id)
     (org-roam-capture--setup-target-location)
     ;; Adjust point for plain captures to skip past metadata (e.g. properties drawer)
@@ -701,9 +701,9 @@ the current value of `point'."
 (add-hook 'org-roam-capture-preface-hook #'org-roam-capture--try-capture-to-ref-h)
 (defun org-roam-capture--try-capture-to-ref-h ()
   "Try to capture to an existing node that match the ref."
-  (when-let ((node (and (plist-get org-roam-capture--info :ref)
-                        (org-roam-node-from-ref
-                         (plist-get org-roam-capture--info :ref)))))
+  (when-let* ((node (and (plist-get org-roam-capture--info :ref)
+                         (org-roam-node-from-ref
+                          (plist-get org-roam-capture--info :ref)))))
     (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
     (goto-char (org-roam-node-point node))
     (widen)
@@ -712,7 +712,7 @@ the current value of `point'."
 (add-hook 'org-roam-capture-new-node-hook #'org-roam-capture--insert-captured-ref-h)
 (defun org-roam-capture--insert-captured-ref-h ()
   "Insert the ref if any."
-  (when-let ((ref (plist-get org-roam-capture--info :ref)))
+  (when-let* ((ref (plist-get org-roam-capture--info :ref)))
     (org-roam-ref-add ref)))
 
 ;;;; Finalizers
@@ -725,8 +725,8 @@ the current value of `point'."
 (defun org-roam-capture--finalize ()
   "Finalize the `org-roam-capture' process."
   (if org-note-abort
-      (when-let ((new-file (org-roam-capture--get :new-file))
-                 (_ (yes-or-no-p "Delete file for aborted capture?")))
+      (when-let* ((new-file (org-roam-capture--get :new-file))
+                  (_ (yes-or-no-p "Delete file for aborted capture?")))
         (when (find-buffer-visiting new-file)
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
@@ -754,7 +754,7 @@ This function is to be called in the Org-capture finalization process."
   (when-let* ((mkr (org-roam-capture--get :call-location))
               (buf (marker-buffer mkr)))
     (with-current-buffer buf
-      (when-let ((region (org-roam-capture--get :region)))
+      (when-let* ((region (org-roam-capture--get :region)))
         (delete-region (car region) (cdr region))
         (set-marker (car region) nil)
         (set-marker (cdr region) nil))

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -157,7 +157,7 @@ nodes." org-id-locations-file)
     (advice-add 'org-roam-capture--get-target :around #'org-roam-capture--get-if-new-target-a)
     (defun org-roam-capture--get-if-new-target-a (fn &rest args)
       "Get the current capture target using deprecated :if-new property."
-      (if-let ((target (org-roam-capture--get :if-new)))
+      (if-let* ((target (org-roam-capture--get :if-new)))
           (prog1 target
             (unless inhibit-warning-p
               (lwarn 'org-roam-capture :warning

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -297,12 +297,12 @@ If HASH is non-nil, use that as the file's hash without recalculating it."
 
 (defun org-roam-db-get-scheduled-time ()
   "Return the scheduled time at point in ISO8601 format."
-  (when-let ((time (org-get-scheduled-time (point))))
+  (when-let* ((time (org-get-scheduled-time (point))))
     (format-time-string "%FT%T" time)))
 
 (defun org-roam-db-get-deadline-time ()
   "Return the deadline time at point in ISO8601 format."
-  (when-let ((time (org-get-deadline-time (point))))
+  (when-let* ((time (org-get-deadline-time (point))))
     (format-time-string "%FT%T" time)))
 
 (defun org-roam-db-node-p ()
@@ -362,7 +362,7 @@ INFO is the org-element parsed buffer."
   (org-with-point-at 1
     (when (and (= (org-outline-level) 0)
                (org-roam-db-node-p))
-      (when-let ((id (org-id-get)))
+      (when-let* ((id (org-id-get)))
         (let* ((file (buffer-file-name (buffer-base-buffer)))
                (title (org-roam-db--file-title))
                (pos (point))
@@ -395,7 +395,7 @@ INFO is the org-element parsed buffer."
 
 (cl-defun org-roam-db-insert-node-data ()
   "Insert node data for headline at point into the Org-roam cache."
-  (when-let ((id (org-id-get)))
+  (when-let* ((id (org-id-get)))
     (let* ((file (buffer-file-name (buffer-base-buffer)))
            (heading-components (org-heading-components))
            (pos (point))
@@ -436,8 +436,8 @@ INFO is the org-element parsed buffer."
 
 (defun org-roam-db-insert-tags ()
   "Insert tags for node at point into Org-roam cache."
-  (when-let ((node-id (org-id-get))
-             (tags (org-get-tags)))
+  (when-let* ((node-id (org-id-get))
+              (tags (org-get-tags)))
     (org-roam-db-query [:insert :into tags
                         :values $v1]
                        (mapcar (lambda (tag)

--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -47,7 +47,7 @@ With optional argument MARKERP, return the position as a new marker."
    ((symbolp id) (setq id (symbol-name id)))
    ((numberp id) (setq id (number-to-string id))))
   (let ((node (org-roam-populate (org-roam-node-create :id id))))
-    (when-let ((file (org-roam-node-file node)))
+    (when-let* ((file (org-roam-node-file node)))
       (if markerp
           (let ((buffer (or (find-buffer-visiting file)
                             (find-file-noselect file))))

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -151,9 +151,9 @@ If the property is already set, replace its value."
              (desc (match-string 2)))
         (when (string-prefix-p "file:" path)
           (setq path (expand-file-name (substring path 5)))
-          (when-let ((node-id (caar (org-roam-db-query [:select [id] :from nodes
-                                                        :where (= file $s1)
-                                                        :and (= level 0)] path))))
+          (when-let* ((node-id (caar (org-roam-db-query [:select [id] :from nodes
+                                                         :where (= file $s1)
+                                                         :and (= level 0)] path))))
             (set-match-data mdata)
             (replace-match (org-link-make-string (concat "id:" node-id)
                                                  desc) nil t)))))))

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -208,11 +208,11 @@ which visits the thing at point."
 (defun org-roam-buffer-file-at-point (&optional assert)
   "Return the file at point in the current `org-roam-mode' based buffer.
 If ASSERT, throw an error."
-  (if-let ((file (magit-section-case
-                   (org-roam-node-section (org-roam-node-file (oref it node)))
-                   (org-roam-grep-section (oref it file))
-                   (org-roam-preview-section (oref it file))
-                   (t (cl-assert (derived-mode-p 'org-roam-mode))))))
+  (if-let* ((file (magit-section-case
+                    (org-roam-node-section (org-roam-node-file (oref it node)))
+                    (org-roam-grep-section (oref it file))
+                    (org-roam-preview-section (oref it file))
+                    (t (cl-assert (derived-mode-p 'org-roam-mode))))))
       file
     (when assert
       (user-error "No file at point"))))
@@ -324,7 +324,7 @@ Valid states are `visible', `exists' and `none'."
 (defun org-roam-buffer-persistent-redisplay ()
   "Recompute contents of the persistent `org-roam-buffer'.
 Has no effect when there's no `org-roam-node-at-point'."
-  (when-let ((node (org-roam-node-at-point)))
+  (when-let* ((node (org-roam-node-at-point)))
     (unless (equal node org-roam-buffer-current-node)
       (setq org-roam-buffer-current-node node
             org-roam-buffer-current-directory org-roam-directory)
@@ -387,7 +387,7 @@ the same time:
    other node) at POINT. Acts a child section of the previous
    one."
   (magit-insert-section section (org-roam-node-section)
-    (let ((outline (if-let ((outline (plist-get properties :outline)))
+    (let ((outline (if-let* ((outline (plist-get properties :outline)))
                        (mapconcat #'org-link-display-format outline " > ")
                      "Top")))
       (insert (concat (propertize (org-roam-node-title source-node)
@@ -519,7 +519,7 @@ When SHOW-BACKLINK-P is not null, only show backlinks for which
 this predicate is not nil.
 
 SECTION-HEADING is the string used as a heading for the backlink section."
-  (when-let ((backlinks (seq-sort #'org-roam-backlinks-sort (org-roam-backlinks-get node :unique unique))))
+  (when-let* ((backlinks (seq-sort #'org-roam-backlinks-sort (org-roam-backlinks-get node :unique unique))))
     (magit-insert-section (org-roam-backlinks)
       (magit-insert-heading section-heading)
       (dolist (backlink backlinks)
@@ -577,8 +577,8 @@ Sorts by title."
 
 (defun org-roam-reflinks-section (node)
   "The reflinks section for NODE."
-  (when-let ((refs (org-roam-node-refs node))
-             (reflinks (seq-sort #'org-roam-reflinks-sort (org-roam-reflinks-get node))))
+  (when-let* ((refs (org-roam-node-refs node))
+              (reflinks (seq-sort #'org-roam-reflinks-sort (org-roam-reflinks-get node))))
     (magit-insert-section (org-roam-reflinks)
       (magit-insert-heading "Reflinks:")
       (dolist (reflink reflinks)

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -269,7 +269,7 @@ populated."
                                   (org-roam-up-heading-or-point-min)
                                   (funcall outline-level)))))
               (org-roam-up-heading-or-point-min))
-            (when-let ((id (org-id-get)))
+            (when-let* ((id (org-id-get)))
               (org-roam-populate
                (org-roam-node-create
                 :id id
@@ -321,15 +321,15 @@ Return nil if there's no node with such REF."
         (setq type "cite"
               path (substring ref 1))))
       (when (and type path)
-        (when-let ((id (caar (org-roam-db-query
-                              [:select [nodes:id]
-                               :from refs
-                               :left-join nodes
-                               :on (= refs:node-id nodes:id)
-                               :where (= refs:type $s1)
-                               :and (= refs:ref $s2)
-                               :limit 1]
-                              type path))))
+        (when-let* ((id (caar (org-roam-db-query
+                               [:select [nodes:id]
+                                :from refs
+                                :left-join nodes
+                                :on (= refs:node-id nodes:id)
+                                :where (= refs:type $s1)
+                                :and (= refs:ref $s2)
+                                :limit 1]
+                               type path))))
           (org-roam-populate (org-roam-node-create :id id)))))))
 
 (cl-defmethod org-roam-populate ((node org-roam-node))
@@ -337,13 +337,13 @@ Return nil if there's no node with such REF."
 Uses the ID, and fetches remaining details from the database.
 This can be quite costly: avoid, unless dealing with very few
 nodes."
-  (when-let ((node-info (car (org-roam-db-query [:select [
-                                                          file level pos todo priority
-                                                          scheduled deadline title properties olp]
-                                                 :from nodes
-                                                 :where (= id $s1)
-                                                 :limit 1]
-                                                (org-roam-node-id node)))))
+  (when-let* ((node-info (car (org-roam-db-query [:select [
+                                                           file level pos todo priority
+                                                           scheduled deadline title properties olp]
+                                                  :from nodes
+                                                  :where (= id $s1)
+                                                  :limit 1]
+                                                 (org-roam-node-id node)))))
     (pcase-let* ((`(,file ,level ,pos ,todo ,priority ,scheduled ,deadline ,title ,properties ,olp) node-info)
                  (`(,atime ,mtime ,file-title) (car (org-roam-db-query [:select [atime mtime title]
                                                                         :from files
@@ -770,7 +770,7 @@ The INFO, if provided, is passed to the underlying `org-roam-capture-'."
 (defun org-roam-link-follow-link (title-or-alias)
   "Navigate \"roam:\" link to find and open the node with TITLE-OR-ALIAS.
 Assumes that the cursor was put where the link is."
-  (if-let ((node (org-roam-node-from-title-or-alias title-or-alias)))
+  (if-let* ((node (org-roam-node-from-title-or-alias title-or-alias)))
       (progn
         (when org-roam-link-auto-replace
           (org-roam-link-replace-at-point))

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -424,7 +424,7 @@ straight.el on Windows.
 See <https://github.com/raxod502/straight.el/issues/520>."
   (when (and (bound-and-true-p straight-symlink-emulation-mode)
              (fboundp 'straight-chase-emulated-symlink))
-    (when-let ((target (straight-chase-emulated-symlink filename)))
+    (when-let* ((target (straight-chase-emulated-symlink filename)))
       (unless (eq target 'broken)
         (setq filename target))))
   (file-chase-links filename))
@@ -445,7 +445,7 @@ See <https://github.com/raxod502/straight.el/issues/520>."
     (insert (format "- Org: %s\n" (org-version nil 'full)))
     (insert (format "- Org-roam: %s" (org-roam-version)))
     (insert (format "- sqlite-connector: %s"
-                    (if-let ((conn (org-roam-db--get-connection)))
+                    (if-let* ((conn (org-roam-db--get-connection)))
                         (eieio-object-class conn)
                       "not connected")))))
 


### PR DESCRIPTION
###### Motivation for this change

This fixes the noisy compile-log messages that come up if you're running Emacs 31 and install or update org-roam.

They are also seen in the test workflows, example from https://github.com/org-roam/org-roam/pull/2558/checks:

```
[00:02.521]  org-roam-compat.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.524]  org-roam-utils.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.524]  org-roam-utils.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.526]  org-roam-db.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.526]  org-roam-db.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.527]  org-roam-db.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.527]  org-roam-db.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.527]  org-roam-db.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.533]  org-roam-node.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.534]  org-roam-node.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.534]  org-roam-node.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.537]  org-roam-node.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.541]  org-roam-id.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.543]  org-roam-capture.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.544]  org-roam-capture.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.544]  org-roam-capture.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.544]  org-roam-capture.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.544]  org-roam-capture.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.546]  org-roam-mode.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.547]  org-roam-mode.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.547]  org-roam-mode.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
[00:02.549]  org-roam-mode.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.550]  org-roam-mode.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
[00:02.555]  org-roam-migrate.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
```