### PR TITLE
style: use pgformatter on the huge sql expression

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -378,77 +378,78 @@ nodes."
 
 (defun org-roam-node-list ()
   "Return all nodes stored in the database as a list of `org-roam-node's."
-  (let ((rows (org-roam-db-query
-               "
+  (let ((rows (org-roam-db-query "
 SELECT
-  title,
-  aliases,
-
-  id,
-  file,
-  filetitle,
-  \"level\",
-  todo,
-
-  pos,
-  priority ,
-  scheduled ,
-  deadline ,
-  properties ,
-
-  olp,
-  atime,
-  mtime,
-  '(' || group_concat(tags, ' ') || ')' as tags,
-  refs
-FROM
-  (
-  SELECT
-    id,
-    file,
-    filetitle,
-    \"level\",
-    todo,
-    pos,
-    priority ,
-    scheduled ,
-    deadline ,
-    title,
-    properties ,
-    olp,
-    atime,
-    mtime,
-    tags,
-    '(' || group_concat(aliases, ' ') || ')' as aliases,
-    refs
-  FROM
-    (
-    SELECT
-      nodes.id as id,
-      nodes.file as file,
-      nodes.\"level\" as \"level\",
-      nodes.todo as todo,
-      nodes.pos as pos,
-      nodes.priority as priority,
-      nodes.scheduled as scheduled,
-      nodes.deadline as deadline,
-      nodes.title as title,
-      nodes.properties as properties,
-      nodes.olp as olp,
-      files.atime as atime,
-      files.mtime as mtime,
-      files.title as filetitle,
-      tags.tag as tags,
-      aliases.alias as aliases,
-      '(' || group_concat(RTRIM (refs.\"type\", '\"') || ':' || LTRIM(refs.ref, '\"'), ' ') || ')' as refs
-    FROM nodes
-    LEFT JOIN files ON files.file = nodes.file
-    LEFT JOIN tags ON tags.node_id = nodes.id
-    LEFT JOIN aliases ON aliases.node_id = nodes.id
-    LEFT JOIN refs ON refs.node_id = nodes.id
-    GROUP BY nodes.id, tags.tag, aliases.alias )
-  GROUP BY id, tags )
-GROUP BY id
+        title,
+        aliases,
+        id,
+        file,
+        filetitle,
+        \"level\",
+        todo,
+        pos,
+        priority,
+        scheduled,
+        deadline,
+        properties,
+        olp,
+        atime,
+        mtime,
+        '(' || group_concat(tags, ' ') || ')' AS tags,
+        refs
+FROM (
+        SELECT
+                id,
+                file,
+                filetitle,
+                \"level\",
+                todo,
+                pos,
+                priority,
+                scheduled,
+                deadline,
+                title,
+                properties,
+                olp,
+                atime,
+                mtime,
+                tags,
+                '(' || group_concat(aliases, ' ') || ')' AS aliases,
+                refs
+        FROM (
+                SELECT
+                        nodes.id AS id,
+                        nodes.file AS file,
+                        nodes.\"level\" AS \"level\",
+                        nodes.todo AS todo,
+                        nodes.pos AS pos,
+                        nodes.priority AS priority,
+                        nodes.scheduled AS scheduled,
+                        nodes.deadline AS deadline,
+                        nodes.title AS title,
+                        nodes.properties AS properties,
+                        nodes.olp AS olp,
+                        files.atime AS atime,
+                        files.mtime AS mtime,
+                        files.title AS filetitle,
+                        tags.tag AS tags,
+                        aliases.alias AS aliases,
+                        '(' || group_concat(RTRIM(refs. \"type\", '\"') || ':' || LTRIM(refs.ref, '\"'), ' ') || ')' AS refs
+                FROM
+                        nodes
+                LEFT JOIN files ON files.file = nodes.file
+                LEFT JOIN tags ON tags.node_id = nodes.id
+                LEFT JOIN aliases ON aliases.node_id = nodes.id
+                LEFT JOIN refs ON refs.node_id = nodes.id
+        GROUP BY
+                nodes.id,
+                tags.tag,
+                aliases.alias)
+GROUP BY
+        id,
+        tags)
+GROUP BY
+        id
 ")))
     (mapcan
      (lambda (row)


### PR DESCRIPTION
###### Motivation for this change

I find it easier to read. Agree?

It's a purely whitespace change (and some lowercase->uppercase), courtesy of the `pgformatter` tool.

EDIT: D'oh, it falls afoul of the 110-char line length maximum.

## Sidenote

I was interested to learn that this expression dates all the way from the release of v2, with only minor changes since. Original from the v2 commit can be found here: https://github.com/org-roam/org-roam/blob/aee3467b3e89ddf49393584586252c2fb4509433/org-roam.el

I feel like there ought to be a way to make this a lot shorter. At least, the EmacSQL expression used in v1 was short, but v1 made different assumptions of course: 

https://github.com/org-roam/org-roam/blob/756f6215b672e267f986a3d6e494f5309825b91a/org-roam.el#L905-L909