### PR TITLE
fix: Fontify the org-roam buffer again

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -179,7 +179,9 @@ information in a section-like manner (see
 `org-roam-mode-sections'), with which the user can
 interact with."
   :group 'org-roam
-  (face-remap-add-relative 'header-line 'org-roam-header-line))
+  (face-remap-add-relative 'header-line 'org-roam-header-line)
+  ;; https://github.com/meedstrom/org-node/issues/149
+  (setq-local font-lock-defaults nil))
 
 ;;; Buffers
 (defvar org-roam-buffer-current-node nil


### PR DESCRIPTION
###### Motivation for this change

The org-roam buffer has apparently been rendering backlink previews with no fontification for a few months(?).  This fixes that.

More info: https://github.com/meedstrom/org-node/issues/149#issuecomment-3505199482