### PR TITLE
Gather dirty load effects into a single mode

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -310,7 +310,8 @@ Return (MONTH DAY YEAR) or nil if not an Org time-string."
 
 (defun org-roam-dailies-calendar-mark-entries ()
   "Mark days in the calendar for which a daily-note is present."
-  (when (file-exists-p (expand-file-name org-roam-dailies-directory org-roam-directory))
+  (when (and org-roam-enabled
+             (file-exists-p (expand-file-name org-roam-dailies-directory org-roam-directory)))
     (dolist (date (remove nil
                           (mapcar #'org-roam-dailies-calendar--file-to-date
                                   (org-roam-dailies--list-files))))

--- a/extensions/org-roam-protocol.el
+++ b/extensions/org-roam-protocol.el
@@ -113,6 +113,7 @@ See `org-roam-capture-templates' for the template documentation."
                                          ((const :format "%v " :kill-buffer) (const t))))))))
 
 ;;; Handlers
+;;;###autoload
 (defun org-roam-protocol-open-ref (info)
   "Process an org-protocol://roam-ref?ref= style url with INFO.
 
@@ -150,6 +151,7 @@ It opens or creates a note with the given ref.
      :templates org-roam-capture-ref-templates))
   nil)
 
+;;;###autoload
 (defun org-roam-protocol-open-node (info)
   "This handler simply opens the file with emacsclient.
 
@@ -163,11 +165,6 @@ org-protocol://roam-node?node=uuid"
     (raise-frame)
     (org-roam-node-visit (org-roam-populate (org-roam-node-create :id node)) nil 'force))
   nil)
-
-(push '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)
-      org-protocol-protocol-alist)
-(push '("org-roam-node"  :protocol "roam-node"   :function org-roam-protocol-open-node)
-      org-protocol-protocol-alist)
 
 (provide 'org-roam-protocol)
 

--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -59,8 +59,6 @@ With optional argument MARKERP, return the position as a new marker."
 (defalias 'org-roam-id-open 'org-id-open
   "Obsolete alias - use `org-id-open' directly.")
 
-(advice-add 'org-id-find :before-until #'org-roam-id-find)
-
 ;;;###autoload
 (defun org-roam-update-org-id-locations (&rest directories)
   "Scan Org-roam files to update `org-id' related state.

--- a/org-roam-log.el
+++ b/org-roam-log.el
@@ -41,7 +41,6 @@
   (run-hooks 'org-roam-log-setup-hook))
 
 (add-hook 'org-roam-log-setup-hook #'org-roam--register-completion-functions-h)
-(add-hook 'org-log-buffer-setup-hook #'org-roam-log--setup)
 
 (provide 'org-roam-log)
 ;;; org-roam-log.el ends here

--- a/org-roam.el
+++ b/org-roam.el
@@ -93,6 +93,7 @@
 (require 'ol)
 (require 'org-element)
 (require 'org-capture)
+(require 'org-protocol)
 
 (require 'ansi-color) ; to strip ANSI color codes in `org-roam--list-files'
 
@@ -345,6 +346,38 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
       (when (and (file-readable-p file)
                  (org-roam-file-p file))
         (push file result)))))
+
+(defvar org-roam-enabled nil)
+(define-minor-mode org-roam-core-mode
+  "Configure Emacs for org-roam."
+  :group 'org-roam
+  :global t
+  (let ((node-protocol '("org-roam-node" :protocol "roam-node" :function org-roam-protocol-open-node))
+        (ref-protocol  '("org-roam-ref"  :protocol "roam-ref"  :function org-roam-protocol-open-ref)))
+    (if org-roam-core-mode
+        (progn
+          (setq org-roam-enabled t)
+          (advice-add 'org-id-find :before-until #'org-roam-id-find)
+          (add-hook 'org-log-buffer-setup-hook #'org-roam-log--setup)
+          (push node-protocol org-protocol-protocol-alist)
+          (push ref-protocol org-protocol-protocol-alist))
+      (setq org-roam-enabled nil)
+      (advice-remove 'org-id-find #'org-roam-id-find)
+      (remove-hook 'org-log-buffer-setup-hook #'org-roam-log--setup)
+      (setq org-protocol-protocol-alist (->> org-protocol-protocol-alist
+                                             (delete node-protocol)
+                                             (delete ref-protocol))))))
+
+;; In general, just loading a .el file should have no effect on the Emacs session,
+;; other than defining functions and variables.
+;; Enabling a mode is what is allowed to mutate other things,
+;; and the effects should be reversible by disabling the mode.
+
+;; However, org-roam has never obeyed that principle, so users won't expect
+;; to have to enable a new mode to make things work again after an update.
+;; Therefore, we enable the mode on load, avoiding any surprises on update.
+;; This at least provides something that the user can disable.
+(org-roam-core-mode 1)
 
 ;;; Package bootstrap
 (provide 'org-roam)


### PR DESCRIPTION
In general, just loading a `*.el` file should have no effect on the Emacs session, other than defining functions and variables.   If a package needs to cause side effects, it is best practice to do so in a mode, not on load.

This PR moves all side effects that I know of, into a new mode `org-roam-core-mode`.

To avoid breaking things for users, it is enabled on load (heh). 

###### Motivation for this change

I know it's a bit iffy to add a whole new mode. There's no rush with this PR.

But I have myself had issues with org-roam's lack of hygiene not once, but *twice*, while developing [org-node](https://github.com/meedstrom/org-node):

1. The fact that the calendar is always marked according to which days have an `org-roam-dailies` entry... unconditionally. Even in `org-read-date` popups not called by org-roam!
 
   It means that org-node can't mark days its own way if the user has loaded `org-roam-dailies`.  User basically has to restart Emacs and be careful to do nothing that accidentally loads `org-roam-dailies`.

   - Offending lines are https://github.com/meedstrom/org-roam/blob/ecb9747f0e0be89607ebe2d4ec1a3fe84f940b9f/extensions/org-roam-dailies.el#L321-L322, but I didn't want to move them into the new `org-roam-core-mode`, as that would make it necessary to always load `org-roam-dailies`.  Instead, I made the function into a potential no-op dependent on the new variable `org-roam-enabled`, which is tied to that mode.

2. The fact that `org-roam-id-find` preferentially looks in the `org-roam-db` means that if the user has disabled `org-roam-db-autosync-mode`, you can get a strange situation where org-id might actually know the current, correct location of an ID, but clicking on an ID-link results in trying to visit the location where the (stale) `org-roam-db` thinks it is.  Sending the user to a new blank file, under the file-name that *used to be* associated with that ID.

   In my package, I tried to keep the `org-id-locations` table updated, and then trust that *clicking on ID-links does look up that table*. Imagine my confusion.

Anyway, neither of these would've been much of a problem if there was some mode that the user could easily disable.