### PR TITLE
test: Lots more tests

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -888,10 +888,15 @@ and no extra content before the first heading."
    (org-with-point-at 1 (org-at-heading-p))))
 
 (defun org-roam-promote-entire-buffer ()
-  "Promote the current buffer.
+  "Promote the current buffer, and save.
 Converts a file containing a single level-1 headline node to a file
 node."
   (interactive)
+  (org-roam--promote-entire-buffer-internal)
+  (org-roam-db-update-file))
+
+(defun org-roam--promote-entire-buffer-internal ()
+  "Promote the current buffer."
   (unless (org-roam--buffer-promoteable-p)
     (user-error "Cannot promote: multiple root headings or there is extra file-level text"))
   (org-with-point-at 1
@@ -902,8 +907,7 @@ node."
       (org-roam-end-of-meta-data t)
       (insert "#+title: " title "\n")
       (when tags (org-roam-tag-add tags))
-      (org-map-region #'org-promote (point-min) (point-max))
-      (org-roam-db-update-file))))
+      (org-map-region #'org-promote (point-min) (point-max)))))
 
 ;;;###autoload
 (defun org-roam-refile (node)

--- a/tests/roam-files/alternative-id-methods.org
+++ b/tests/roam-files/alternative-id-methods.org
@@ -1,0 +1,11 @@
+#+title: Alternative ID methods
+
+* With =org-id-method= set to =org=
+:PROPERTIES:
+:ID:       nl4ibn507rk0
+:END:
+
+* With =org-id-method= set to =ts=
+:PROPERTIES:
+:ID:       20251111T122245.135537
+:END:

--- a/tests/roam-files/dailies/2025-11-11.org
+++ b/tests/roam-files/dailies/2025-11-11.org
@@ -1,0 +1,4 @@
+:PROPERTIES:
+:ID:       75200446-930f-4ce5-9b05-1aa574aa2a95
+:END:
+#+title: 2025-11-11

--- a/tests/roam-files/promoteable.org
+++ b/tests/roam-files/promoteable.org
@@ -1,3 +1,23 @@
-* Promoteable h1
+* TODO [#A] [1/2] Promoteable h1
+SCHEDULED: <2025-11-12 Wed 11:47>
+:PROPERTIES:
+:ID:       77f66521-2dfb-49b0-bcc4-9f02f622343b
+:END:
 
-** Promoteable child
+- NOT IMPLEMENTED as of [2025-11-12 Wed]: the SCHEDULED-line should probably disappear upon promoting this heading into a file-level node, or at least move down to after the :PROPERTIES: drawer.  Otherwise Org thinks there are no properties and thus no file-level node!
+
+- The =TODO [#A] [1/2]= is probably reasonable to leave to the user to fix up manually, if they so desire.
+
+** DONE [#B] [100%] Promoteable child
+CLOSED: [2025-11-12 Wed 12:03]
+:PROPERTIES:
+:ID:       0b6301cb-292a-4a6b-be42-330c2caf9618
+:END:
+Messy
+
+:drawer:
+:end:
+
+content.
+
+** TODO Promoteable child 2

--- a/tests/roam-files/roam-exclude.org
+++ b/tests/roam-files/roam-exclude.org
@@ -5,3 +5,33 @@
 #+TITLE: Excluded by Org-roam
 
 This node is excluded by declaring ~ROAM_EXCLUDE: t~.
+
+* Another excluded node
+:PROPERTIES:
+:ID:       b2432fe5-0aab-4e1a-b83c-809a899a79f8
+:END:
+
+This should *in theory* be excluded due to inheriting the =ROAM_EXCLUDE= property...
+
+However, it turns out that org-roam has probably never worked that way!  May be too late to change, then.
+
+* Not excluded
+:PROPERTIES:
+:ID:       295aa41a-4318-4b17-b98c-b2a9e85e4525
+:ROAM_EXCLUDE: nil
+:END:
+
+This should not be excluded, due to overriding the inherited =ROAM_EXCLUDE= property to the magical string "nil", which Org interprets as the Lisp symbol =nil=.  See =org-entry-get=.
+
+** Also not excluded
+:PROPERTIES:
+:ID:       0e02f465-0fd9-404c-b3bc-1138e9c0cdf2
+:END:
+
+** Excluded but without "t"
+:PROPERTIES:
+:ID:       aa3b8409-e918-44af-8f2f-b4639f812573
+:ROAM_EXCLUDE:
+:END:
+
+Technically, it doesn't have to be "t", just anything other than "nil".

--- a/tests/roam-files/subdirectory/node-in-subdirectory.org
+++ b/tests/roam-files/subdirectory/node-in-subdirectory.org
@@ -1,0 +1,4 @@
+:PROPERTIES:
+:ID:       a0abdc75-4bdc-48e9-9560-d79565f78504
+:END:
+#+title: A node in a subdirectory

--- a/tests/roam-files/title-transformations.org
+++ b/tests/roam-files/title-transformations.org
@@ -1,0 +1,30 @@
+#+todo: IDEA | DONE
+* A title with an [[https://gnu.org][embedded link]]
+:PROPERTIES:
+:ID:       70451c3f-0bea-4f0a-8a8e-15d7fd133130
+:END:
+This can be used to test that the node title is transformed by =org-link-display-format=.
+
+* Title linking to [[id:70451c3f-0bea-4f0a-8a8e-15d7fd133130][A title with an embedded link]]
+:PROPERTIES:
+:ID:       b15be55a-a8da-4ce5-8360-96b8eec6845b
+:END:
+This too, except that it's an ID-link that should still count for backlinks.
+
+* IDEA [#A] [100%] A title with a TODO-state, priority and [10/10] multiple statistics-cookies [10/10]
+:PROPERTIES:
+:ID:       ca1a671f-5b08-4248-85aa-c91febba651f
+:END:
+Only the todo-state and priority are to be removed.
+
+* TODO A title that appears on first glance to have a TODO-state
+:PROPERTIES:
+:ID:       2d4e00c3-3346-43b6-a421-e8147bd865c0
+:END:
+"TODO" isn't one of the words in the file-local =#+todo:= settings, so it should naturally stay part of the title, not be removed.
+
+* A title with /italics/, *bold*, _underline_, +strikethrough+ and =monospace=
+:PROPERTIES:
+:ID:       35992759-8187-4f57-9721-a5b04df019b6
+:END:
+These are preserved.

--- a/tests/roam-files/with-alias.org
+++ b/tests/roam-files/with-alias.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
 :ID: 57ff3ce7-5bda-4825-8fca-c09f523e87ba
-:ROAM_ALIASES: Batman
+:ROAM_ALIASES: Batman "The Dark Knight"
 :END:
 #+title: Bruce Wayne

--- a/tests/roam-files/with-times.org
+++ b/tests/roam-files/with-times.org
@@ -14,3 +14,17 @@ DEADLINE: <2024-07-17 Tue>
 :PROPERTIES:
 :ID: 3ab84701-d1c1-463f-b5c6-715e6ff5a0bf
 :END:
+
+* DONE Full planning-line
+DEADLINE: <2024-07-17 Tue> CLOSED: <2024-07-17 Tue> SCHEDULED: <2024-07-17 Tue>
+:PROPERTIES:
+:ID:       52a56921-3e2b-46d6-9090-dfe6afcb8504
+:END:
+
+* With CLOSED but no "DONE"
+CLOSED: <2024-07-17 Tue>
+:PROPERTIES:
+:ID:       8d277b3c-b207-4326-8ead-c514e93c7f79
+:END:
+
+That should be fine.

--- a/tests/test-org-roam-db.el
+++ b/tests/test-org-roam-db.el
@@ -78,37 +78,26 @@
     (org-roam-db--close)
     (delete-file org-roam-db-location))
 
-  (it "has the correct number of files"
+  (it "makes the correct number of rows in files table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from files]))
             :to-equal
-            9))
+            13))
 
-  (it "has the correct number of nodes"
+  (it "makes the correct number of rows in nodes table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from nodes]))
             :to-equal
-            12))
+            28))
 
-  (it "has the correct number of links"
+  (it "makes the correct number of rows in links table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from links]))
             :to-equal
-            1))
+            3))
 
   (it "respects ROAM_EXCLUDE"
-    ;; The excluded node has ID "53fadc75-f48e-461e-be06-44a1e88b2abe"
     (expect (mapcar #'car (org-roam-db-query [:select id :from nodes]))
-            :to-have-same-items-as
-            '("884b2341-b7fe-434d-848c-5282c0727861"
-              "440795d0-70c1-4165-993d-aebd5eef7a24"
-              "5b9a7400-f59c-4ef9-acbb-045b69af98f1"
-              "0fa5bb3e-3d8c-4966-8bc9-78d32e505d69"
-              "5fb4fdc5-b6d2-4f75-8d54-e60053e467ec"
-              "77a90980-1994-464e-901f-7e3d3df07fd3"
-              "57ff3ce7-5bda-4825-8fca-c09f523e87ba"
-              "998b2341-b7fe-434d-848c-5282c0727870"
-              "a523c198-4cb4-44d2-909c-a0e3258089cd"
-              "3ab84701-d1c1-463f-b5c6-715e6ff5a0bf"
-              "9a20ca6c-5555-41c9-a039-ac38bf59c7a9"
-              "97bf31cf-dfee-45d8-87a5-2ae0dabc4734")))
+            :not :to-contain "53fadc75-f48e-461e-be06-44a1e88b2abe")
+    (expect (mapcar #'car (org-roam-db-query [:select id :from nodes]))
+            :not :to-contain "aa3b8409-e918-44af-8f2f-b4639f812573"))
 
   (it "reads ref in quotes correctly"
     (expect (mapcar #'car (org-roam-db-query [:select [ref] :from refs]))

--- a/tests/test-org-roam-utils.el
+++ b/tests/test-org-roam-utils.el
@@ -40,12 +40,14 @@
   (it "supports normal titles"
     (expect
      (with-temp-buffer
+       (org-mode)
        (insert "#+title:normal title")
        (org-roam-db--file-title))
      :to-equal "normal title"))
   (it "supports multi-line titles"
     (expect
      (with-temp-buffer
+       (org-mode)
        (insert "#+title: title:\n#+title: separated by newline")
        (org-roam-db--file-title))
      :to-equal "title: separated by newline"))
@@ -55,6 +57,7 @@
             org-roam-db-location (expand-file-name "org-roam.db" temporary-file-directory)
             org-roam-file-extensions '("org"))
       (with-temp-buffer
+        (org-mode)
         (write-file (expand-file-name "test file.org" org-roam-directory))
         (org-roam-db--file-title)))
     :to-equal "test file"))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -58,17 +58,22 @@
     (delete-file org-roam-db-location))
 
   (it "gets files correctly"
-    (expect (length (org-roam-list-files)) :to-equal 9))
+    (expect (length (org-roam-list-files)) :to-equal 13))
+
+  ;; https://github.com/org-roam/org-roam/pull/2178
+  (it "does not care if org-roam-directory itself matches an exclude rule"
+    (setq org-roam-file-exclude-regexp (regexp-quote org-roam-directory))
+    (expect (length (org-roam-list-files)) :to-equal 13))
 
   (it "respects org-roam-file-extensions"
     (setq org-roam-file-extensions '("md"))
     (expect (length (org-roam-list-files)) :to-equal 1)
     (setq org-roam-file-extensions '("org" "md"))
-    (expect (length (org-roam-list-files)) :to-equal 10))
+    (expect (length (org-roam-list-files)) :to-equal 14))
 
   (it "respects org-roam-file-exclude-regexp"
     (setq org-roam-file-exclude-regexp (regexp-quote "foo.org"))
-    (expect (length (org-roam-list-files)) :to-equal 8)))
+    (expect (length (org-roam-list-files)) :to-equal 12)))
 
 (describe "org-roam--list-files-search-globs"
 


### PR DESCRIPTION
###### Motivation for this change

Let me know if you want me to try to split this into several commits.

One code change is `org-roam-promote-entire-buffer` which now wraps `org-roam--promote-entire-buffer-internal`, because it did surprise me why I could not just use `revert-buffer` or a temp buffer, until I realized that it also saves the buffer, which is not what I expect from most Org functions. Just a nitpick, but having the subroutine did make it simpler to write the test.