### PR TITLE
refactor: Mark obsolete -enable, -disable, -toggle

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -234,6 +234,22 @@ nodes." org-id-locations-file)
 ;;; Obsolete functions
 (make-obsolete 'org-roam-get-keyword 'org-collect-keywords "org-roam 2.0")
 
+;;;###autoload
+(defun org-roam-db-autosync-enable ()
+  "Activate `org-roam-db-autosync-mode'."
+  (declare (obsolete org-roam-db-autosync-mode "2025-11-23"))
+  (org-roam-db-autosync-mode +1))
+
+(defun org-roam-db-autosync-disable ()
+  "Deactivate `org-roam-db-autosync-mode'."
+  (declare (obsolete org-roam-db-autosync-mode "2025-11-23"))
+  (org-roam-db-autosync-mode -1))
+
+(defun org-roam-db-autosync-toggle ()
+  "Toggle `org-roam-db-autosync-mode' enabled/disabled."
+  (declare (obsolete org-roam-db-autosync-mode "2025-11-23"))
+  (org-roam-db-autosync-mode 'toggle))
+
 (provide 'org-roam-compat)
 
 ;;; org-roam-compat.el ends here

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -662,19 +662,6 @@ database, see `org-roam-db-sync' command."
         (with-current-buffer buf
           (remove-hook 'after-save-hook #'org-roam-db-autosync--try-update-on-save-h t)))))))
 
-;;;###autoload
-(defun org-roam-db-autosync-enable ()
-  "Activate `org-roam-db-autosync-mode'."
-  (org-roam-db-autosync-mode +1))
-
-(defun org-roam-db-autosync-disable ()
-  "Deactivate `org-roam-db-autosync-mode'."
-  (org-roam-db-autosync-mode -1))
-
-(defun org-roam-db-autosync-toggle ()
-  "Toggle `org-roam-db-autosync-mode' enabled/disabled."
-  (org-roam-db-autosync-mode 'toggle))
-
 (defun org-roam-db-autosync--delete-file-a (file &optional _trash)
   "Maintain cache consistency when file deletes.
 FILE is removed from the database."


### PR DESCRIPTION
###### Motivation for this change

I don't really know why these "enable", "disable", "toggle" wrappers exist, but I would not like it if every mode in Emacs came with similar.  

I'll assume it's legacy from before autosync-mode was a mode.

It'll be a long time before we can remove them, but we can at least declare them obsolete starting now, and declutter org-roam-db.el.