### PR TITLE
test: Do not modify files during test, it creates .#foo.org symlinks

### DIFF
--- a/tests/test-org-roam-node.el
+++ b/tests/test-org-roam-node.el
@@ -214,17 +214,17 @@
 
   (it "adds an alias to a node"
     (cd root-directory)
-    (find-file "tests/roam-files/foo.org" nil)
-    (org-roam-alias-add "qux")
-    (expect (buffer-substring-no-properties (point) (point-max))
-            :to-equal ":PROPERTIES:\n:ID:       884b2341-b7fe-434d-848c-5282c0727861\n:ROAM_ALIASES: qux\n:END:\n#+title: Foo\n"))
+    (org-roam-with-temp-buffer "tests/roam-files/foo.org"
+      (org-roam-alias-add "qux")
+      (expect (buffer-substring-no-properties (point) (point-max))
+              :to-equal ":PROPERTIES:\n:ID:       884b2341-b7fe-434d-848c-5282c0727861\n:ROAM_ALIASES: qux\n:END:\n#+title: Foo\n")))
 
   (it "removes an alias from a node"
     (cd root-directory)
-    (find-file "tests/roam-files/with-alias.org" nil)
-    (org-roam-alias-remove "Batman")
-    (expect (buffer-substring-no-properties (point) (point-max))
-            :to-equal ":PROPERTIES:\n:ID: 57ff3ce7-5bda-4825-8fca-c09f523e87ba\n:ROAM_ALIASES: \"The Dark Knight\"\n:END:\n#+title: Bruce Wayne\n")))
+    (org-roam-with-temp-buffer "tests/roam-files/with-alias.org"
+      (org-roam-alias-remove "Batman")
+      (expect (buffer-substring-no-properties (point) (point-max))
+              :to-equal ":PROPERTIES:\n:ID: 57ff3ce7-5bda-4825-8fca-c09f523e87ba\n:ROAM_ALIASES: \"The Dark Knight\"\n:END:\n#+title: Bruce Wayne\n"))))
 
 (describe "org-roam-node-slug"
   (it "transforms the title as intended"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -58,6 +58,21 @@
     (delete-file org-roam-db-location))
 
   (it "gets files correctly"
+    (expect (mapcar #'file-name-nondirectory (org-roam-list-files))
+            :to-have-same-items-as
+            '("with-times.org"
+              "with-alias.org"
+              "title-transformations.org"
+              "roam-exclude.org"
+              "promoteable.org"
+              "alternative-id-methods.org"
+              "family.org"
+              "demoteable.org"
+              "ref_with_space.org"
+              "foo.org"
+              "bar.org"
+              "node-in-subdirectory.org"
+              "2025-11-11.org"))
     (expect (length (org-roam-list-files)) :to-equal 13))
 
   ;; https://github.com/org-roam/org-roam/pull/2178


### PR DESCRIPTION
Originally part of https://github.com/org-roam/org-roam/pull/2558

During one round of testing, there were
".#foo.org" ".#with-aliases.org" symlinks
during the round, created by earlier tests in the same round...

Also added a test that is more descriptive on failure, 
which would've helped track down aforementioned issue.