### PR TITLE
node: capf: Insert id: links instead of roam: links

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -779,16 +779,14 @@ Completions within link brackets are provided by
 ~org-roam-complete-link-at-point~.
 
 The completion candidates are the titles and aliases for all Org-roam nodes.
-Upon choosing a candidate, a ~roam:Title~ link will be inserted, linking to node
-of choice.
+Choosing a candidate inserts an ID link to the chosen node.
 
 ** Completing anywhere
 
 The same completions can be triggered anywhere for the symbol at point if not
 within a bracketed link. This is provided by ~org-roam-complete-everywhere~.
 Similarly, the completion candidates are the titles and aliases for all Org-roam
-nodes, and upon choosing a candidate a ~roam:Title~ link will be inserted
-linking to the node of choice.
+nodes, and choosing a candidate inserts an ID link to the chosen node.
 
 This is disabled by default. To enable it, set ~org-roam-completion-everywhere~
 to ~t~:

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1106,8 +1106,7 @@ Completions within link brackets are provided by
 @code{org-roam-complete-link-at-point}.
 
 The completion candidates are the titles and aliases for all Org-roam nodes.
-Upon choosing a candidate, a @code{roam:Title} link will be inserted, linking to node
-of choice.
+Choosing a candidate inserts an ID link to the chosen node.
 
 @node Completing anywhere
 @section Completing anywhere
@@ -1115,8 +1114,7 @@ of choice.
 The same completions can be triggered anywhere for the symbol at point if not
 within a bracketed link. This is provided by @code{org-roam-complete-everywhere}.
 Similarly, the completion candidates are the titles and aliases for all Org-roam
-nodes, and upon choosing a candidate a @code{roam:Title} link will be inserted
-linking to the node of choice.
+nodes, and choosing a candidate inserts an ID link to the chosen node.
 
 This is disabled by default. To enable it, set @code{org-roam-completion-everywhere}
 to @code{t}:

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -567,7 +567,7 @@ Return the ID of the location."
     ;; caller.
     (save-excursion
       (goto-char p)
-      (if-let ((id (org-entry-get p "ID")))
+      (if-let* ((id (org-entry-get p "ID")))
           (setf (org-roam-node-id org-roam-capture--node) id)
         (org-entry-put p "ID" (org-roam-node-id org-roam-capture--node)))
       (prog1

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -28,6 +28,7 @@
 ;;; Code:
 (require 'crm)
 (require 'subr-x)
+(eval-when-compile (require 'rx))
 (require 'org-roam)
 
 ;;; Options
@@ -793,7 +794,7 @@ Assumes that the cursor was put where the link is."
 
 ;;;;;; Completion-at-point interface
 (defconst org-roam-bracket-completion-re
-  "\\[\\[\\(\\(?:roam:\\)?\\)\\([^z-a]*?\\)]]"
+  (rx "[[" (group (? "roam:")) (group (*? anything)) "]]")
   "Regex for completion within link brackets.
 We use this as a substitute for `org-link-bracket-re', because
 `org-link-bracket-re' requires content within the brackets for a match.")

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -801,15 +801,15 @@ We use this as a substitute for `org-link-bracket-re', because
 
 (defun org-roam-complete-link-at-point ()
   "Complete \"roam:\" link at point to an existing Org-roam node."
-  (when (org-in-regexp org-roam-bracket-completion-re 1)
+  (when (and (org-in-regexp org-roam-bracket-completion-re 1)
+             (not (org-in-src-block-p)))
     (list (match-beginning 2)
           (match-end 2)
           (org-roam--get-titles)
           :exit-function
           (lambda (str &rest _)
             (delete-char (- 0 (length str)))
-            (insert (concat (when (or (org-in-src-block-p)
-                                      (string-blank-p (match-string 1)))
+            (insert (concat (when (string-blank-p (match-string 1))
                               "roam:")
                             str))
             (forward-char 2)))))

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -794,24 +794,40 @@ Assumes that the cursor was put where the link is."
 
 ;;;;;; Completion-at-point interface
 (defconst org-roam-bracket-completion-re
-  (rx "[[" (group (? "roam:")) (group (*? anything)) "]]")
-  "Regex for completion within link brackets.
-We use this as a substitute for `org-link-bracket-re', because
-`org-link-bracket-re' requires content within the brackets for a match.")
+  (rx "[["
+      (group (opt "roam:"))
+      ;; Change from ‘org-link-bracket-re’: allow empty URI part
+      (group (zero-or-more
+              (or (not (any "[]\\"))
+                  (and "\\" (zero-or-more "\\\\") (any "[]"))
+                  (and (one-or-more "\\") (not (any "[]"))))))
+      "]]")
+  "Regexp for completion within link brackets.
+Intended for ‘org-roam-complete-link-at-point’, which see.")
 
 (defun org-roam-complete-link-at-point ()
-  "Complete \"roam:\" link at point to an existing Org-roam node."
-  (when (and (org-in-regexp org-roam-bracket-completion-re 1)
-             (not (org-in-src-block-p)))
-    (list (match-beginning 2)
-          (match-end 2)
+  "Complete inside link brackets to an existing Org-roam node.
+Targets [[$title]] and [[roam:$title]] links. [[id:$id][$description]]
+links are not targeted to allow for changing link descriptions without
+changing the target node."
+  (when-let* ((_ (org-in-regexp org-roam-bracket-completion-re 1))
+              (uri-start (match-beginning 1))
+              (title-start (match-beginning 2))
+              (end (match-end 2))
+              ;; don’t try to complete if point is in the delimiting brackets
+              (_ (<= title-start (point) end))
+              (_ (not (org-in-src-block-p))))
+    (list title-start end
           (org-roam--get-titles)
           :exit-function
           (lambda (str &rest _)
-            (delete-char (- 0 (length str)))
-            (insert (concat (when (string-blank-p (match-string 1))
-                              "roam:")
-                            str))
+            "Replace title inserted by completion with ID and title."
+            (delete-region uri-start (point))
+            (insert "id:"
+                    (org-roam-node-id (org-roam-node-from-title-or-alias
+                                       (substring-no-properties str)))
+                    "][" str)
+            ;; Move point after closing brackets
             (forward-char 2)))))
 
 (defun org-roam-complete-everywhere ()
@@ -820,7 +836,7 @@ This is a `completion-at-point' function, and is active when
 `org-roam-completion-everywhere' is non-nil.
 
 Unlike `org-roam-complete-link-at-point' this will complete even
-outside of the bracket syntax for links (i.e. \"[[roam:|]]\"),
+outside of the bracket syntax for links (i.e. \"[[|]]\"),
 hence \"everywhere\"."
   (when (and org-roam-completion-everywhere
              (thing-at-point 'word)
@@ -832,7 +848,10 @@ hence \"everywhere\"."
             :exit-function
             (lambda (str _status)
               (delete-char (- (length str)))
-              (insert "[[roam:" str "]]"))
+              (insert "[[id:"
+                      (org-roam-node-id (org-roam-node-from-title-or-alias
+                                         (substring-no-properties str)))
+                      "][" str "]]"))
             ;; Proceed with the next completion function if the returned titles
             ;; do not match. This allows the default Org capfs or custom capfs
             ;; of lower priority to run.

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -801,20 +801,18 @@ We use this as a substitute for `org-link-bracket-re', because
 
 (defun org-roam-complete-link-at-point ()
   "Complete \"roam:\" link at point to an existing Org-roam node."
-  (let (roam-p start end)
-    (when (org-in-regexp org-roam-bracket-completion-re 1)
-      (setq roam-p (not (or (org-in-src-block-p)
-                            (string-blank-p (match-string 1))))
-            start (match-beginning 2)
-            end (match-end 2))
-      (list start end
-            (org-roam--get-titles)
-            :exit-function
-            (lambda (str &rest _)
-              (delete-char (- 0 (length str)))
-              (insert (concat (unless roam-p "roam:")
-                              str))
-              (forward-char 2))))))
+  (when (org-in-regexp org-roam-bracket-completion-re 1)
+    (list (match-beginning 2)
+          (match-end 2)
+          (org-roam--get-titles)
+          :exit-function
+          (lambda (str &rest _)
+            (delete-char (- 0 (length str)))
+            (insert (concat (when (or (org-in-src-block-p)
+                                      (string-blank-p (match-string 1)))
+                              "roam:")
+                            str))
+            (forward-char 2)))))
 
 (defun org-roam-complete-everywhere ()
   "Complete symbol at point as a link completion to an Org-roam node.

--- a/tests/roam-files/capfs.org
+++ b/tests/roam-files/capfs.org
@@ -1,0 +1,15 @@
+* CAPF Node 1
+:PROPERTIES:
+:ID:       196b0cfd-e77e-474a-945b-0e9be25120c9
+:END:
+
+[[id:3822ebf2-b598-46b3-910f-0bfe6930f5d8][id link to Node 2]]
+
+* CAPF Node 2
+:PROPERTIES:
+:ID:       3822ebf2-b598-46b3-910f-0bfe6930f5d8
+:END:
+
+[[id:196b0cfd-e77e-474a-945b-0e9be25120c9][id link to Node 1]]
+
+[[roam:CAPF Node 1][roam link with description]]

--- a/tests/test-org-roam-db.el
+++ b/tests/test-org-roam-db.el
@@ -102,17 +102,17 @@
   (it "makes the correct number of rows in files table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from files]))
             :to-equal
-            17))
+            18))
 
   (it "makes the correct number of rows in nodes table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from nodes]))
             :to-equal
-            36))
+            38))
 
   (it "makes the correct number of rows in links table"
     (expect (caar (org-roam-db-query [:select (funcall count) :from links]))
             :to-equal
-            3))
+            6))
 
   (it "respects ROAM_EXCLUDE"
     (expect (mapcar #'car (org-roam-db-query [:select id :from nodes]))

--- a/tests/test-org-roam-node.el
+++ b/tests/test-org-roam-node.el
@@ -107,7 +107,7 @@
   (it "returns the correct number of node objects"
     ;; Not equal to number of rows in nodes table,
     ;; because it instantiates an extra `org-roam-node' object per alias.
-    (expect (length (org-roam-node-list)) :to-equal 38)))
+    (expect (length (org-roam-node-list)) :to-equal 40)))
 
 (describe "org-roam--h1-count"
   (after-each
@@ -157,6 +157,9 @@
                       "Foo"
                       ;; roam-files/bar.org
                       "Bar"
+                      ;; roam-files/capfs.org
+                      "CAPF Node 1"
+                      "CAPF Node 2"
                       ;; roam-files/with-alias.org
                       "Batman"
                       "The Dark Knight"
@@ -284,10 +287,77 @@
   ;;   (should-not (member ":endgroup" (org-roam-tag-completions))))
 
   (it "has tags that are only in org-tag-alist"
-    (should
-     (cl-subsetp '("@work" "@home" "@tennisclub" "laptop" "pc")
-                 (org-roam-tag-completions)
-                 :test 'equal))))
+      (should
+       (cl-subsetp '("@work" "@home" "@tennisclub" "laptop" "pc")
+                   (org-roam-tag-completions)
+                   :test 'equal))))
+
+(describe "org-roam CAPFs"
+  (before-all
+    (setq org-roam-directory (expand-file-name "tests/roam-files")
+          org-roam-db-location (expand-file-name "org-roam.db" temporary-file-directory)
+          org-roam-file-extensions '("org")
+          org-roam-file-exclude-regexp nil)
+    (org-roam-db-sync)
+    (setq auto-save-default nil)
+    ;; needed to set up hooks
+    (org-roam-db-autosync-mode)
+    (setq org-roam-completion-everywhere t))
+
+  (after-all
+    (org-roam-db--close)
+    (delete-file org-roam-db-location))
+
+  (it "work within links"
+    (find-file "tests/roam-files/capfs.org")
+
+    ;; don’t offer completions when editing link descriptions
+    (search-forward "id link")
+    (expect (org-roam-complete-link-at-point) :to-equal nil)
+    (search-forward "[[id:")
+    (expect (org-roam-complete-link-at-point) :to-equal nil)
+    (search-forward "roam link with description")
+    (expect (org-roam-complete-link-at-point) :to-equal nil)
+
+    (end-of-buffer)
+    (insert "[[")
+    (save-excursion (insert "]]"))
+    (expect (org-roam-complete-everywhere) :to-equal nil)
+    (expect (pcase (org-roam-complete-link-at-point)
+              (`(,(pred integerp) ,(pred integerp)
+                 ,(pred (seq-every-p #'stringp))
+                 :exit-function ,(pred functionp))
+               t)))
+
+    (insert "roam:")
+    (expect (pcase (org-roam-complete-link-at-point)
+              (`(,(pred integerp) ,(pred integerp)
+                 ,(pred (seq-every-p #'stringp))
+                 :exit-function ,(pred functionp))
+               t)))
+
+    ;; don’t offer completions in brackets
+    (forward-char 1)
+    (expect (org-roam-complete-link-at-point) :to-equal nil)
+
+    (set-buffer-modified-p nil)
+    (kill-current-buffer))
+
+  (it "work outside links"
+    (find-file "tests/roam-files/capfs.org")
+
+    (end-of-buffer)
+    (insert "CAPF")
+    (expect (org-roam-complete-link-at-point) :to-equal nil)
+    (expect (pcase (org-roam-complete-everywhere)
+              (`(,(pred integerp) ,(pred integerp)
+                 ,(pred (seq-every-p #'stringp))
+                 :exit-function ,(pred functionp)
+                 :exclusive no)
+               t)))
+
+    (set-buffer-modified-p nil)
+    (kill-current-buffer)))
 
 (provide 'test-org-roam-node)
 

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -58,6 +58,7 @@
                     "ref_with_space.org"
                     "foo.org"
                     "bar.org"
+                    "capfs.org"
                     "node-in-subdirectory.org"
                     "2025-11-11.org"
                     "untitled-1.org"


### PR DESCRIPTION
The org-roam capfs offer existing nodes, so an id: link can be inserted
directly instead of a roam: link that will be replaced on save anyway.

This also tightens the scope of ‘org-roam-bracket-completion-re’ so
‘org-roam-complete-link-at-point’ only activates for relevant links and
‘completion-at-point’ doesn’t get passed nonsense strings like
‘id:$id][$description’ for completing node titles, resulting in “No
match” instead of trying other CAPFs. The new regexp is aligned more
closely with ‘org-link-bracket-re’ to reduce edge cases.

Fixes: #2188
Closes: #2219