### PR TITLE
feat(mode): add imenu support for org-roam-mode buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* (feat): add imenu support for org-roam-mode buffers by @takeokunn in https://github.com/org-roam/org-roam/issues/2274
+
 ## 2.3.1 (2025-06-26)
 
 * (fix): Use correct type specifications to suppress warnings by @okomestudio in https://github.com/org-roam/org-roam/pull/2522

--- a/tests/test-org-roam-mode.el
+++ b/tests/test-org-roam-mode.el
@@ -24,6 +24,44 @@
 (require 'buttercup)
 (require 'org-roam)
 
+(defun test--make-magit-section (type start &optional children)
+  "Create a `magit-section' with TYPE, START position, and optional CHILDREN."
+  (let ((section (make-instance 'magit-section)))
+    (oset section type type)
+    (oset section start start)
+    (oset section children children)
+    section))
+
+(defun test--make-node-section (start node &optional children)
+  "Create an `org-roam-node-section' at START with NODE and optional CHILDREN."
+  (let ((section (make-instance 'org-roam-node-section)))
+    (oset section type 'org-roam-node-section)
+    (oset section start start)
+    (oset section node node)
+    (oset section children children)
+    section))
+
+(defun test--make-preview-section (start file point)
+  "Create an `org-roam-preview-section' at START with FILE and POINT."
+  (let ((section (make-instance 'org-roam-preview-section)))
+    (oset section type 'org-roam-preview-section)
+    (oset section start start)
+    (oset section file file)
+    (oset section point point)
+    (oset section children nil)
+    section))
+
+(defun test--make-grep-section (start file row col)
+  "Create an `org-roam-grep-section' at START with FILE, ROW, and COL."
+  (let ((section (make-instance 'org-roam-grep-section)))
+    (oset section type 'org-roam-grep-section)
+    (oset section start start)
+    (oset section file file)
+    (oset section row row)
+    (oset section col col)
+    (oset section children nil)
+    section))
+
 (describe "org-roam-unlinked-references--rg-command"
   (before-each
     ;; the space in the directory is on purpose
@@ -33,6 +71,196 @@
     (expect (org-roam-unlinked-references--rg-command '("foo" "bar") "/tmp/regex")
             :to-equal
             "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" --file /tmp/regex /tmp/org\\ roam")))
+
+(describe "org-roam-mode-imenu-create-index"
+  (it "returns nil when magit-root-section is nil"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let ((magit-root-section nil))
+        (expect (org-roam-mode-imenu-create-index) :to-be nil))))
+
+  (it "returns empty list when root section has no children"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let ((magit-root-section (test--make-magit-section 'org-roam 1 nil)))
+        (expect (org-roam-mode-imenu-create-index) :to-equal nil))))
+
+  (it "creates nested index for backlinks section"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((preview-section (test--make-preview-section 100 "/tmp/test.org" 50))
+             (mock-node (org-roam-node-create :title "Test Node"))
+             (node-section (test--make-node-section 50 mock-node (list preview-section)))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10 (list node-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let ((index (org-roam-mode-imenu-create-index)))
+          (expect index :not :to-be nil)
+          (expect (length index) :to-equal 1)
+          (expect (caar index) :to-equal "Backlinks")
+          ;; Verify nested structure with markers
+          (let* ((backlinks-entry (car index))
+                 (section-marker (cadr backlinks-entry))
+                 (node-entry (caddr backlinks-entry)))
+            ;; Verify *Section* marker
+            (expect (car section-marker) :to-equal "*Section*")
+            (expect (numberp (cdr section-marker)) :to-be t)
+            ;; Verify node entry structure
+            (expect (car node-entry) :to-equal "Test Node")
+            ;; Verify *Node* marker in nested node entry
+            (let ((node-marker (cadr node-entry)))
+              (expect (car node-marker) :to-equal "*Node*")
+              (expect (numberp (cdr node-marker)) :to-be t))
+            ;; Verify Preview entry
+            (let ((preview-entry (caddr node-entry)))
+              (expect (car preview-entry) :to-equal "Preview")
+              (expect (numberp (cdr preview-entry)) :to-be t)))))))
+
+  (it "creates nested index for reflinks section"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((mock-node (org-roam-node-create :title "Ref Node"))
+             (node-section (test--make-node-section 50 mock-node nil))
+             (reflinks-section (test--make-magit-section 'org-roam-reflinks 10 (list node-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list reflinks-section))))
+        (setq magit-root-section root-section)
+        (let ((index (org-roam-mode-imenu-create-index)))
+          (expect (caar index) :to-equal "Reflinks")))))
+
+  (it "creates nested index for unlinked-references section"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((grep-section (test--make-grep-section 100 "/tmp/test.org" 42 15))
+             (unlinked-section (test--make-magit-section 'unlinked-references 10 (list grep-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list unlinked-section))))
+        (setq magit-root-section root-section)
+        (let ((index (org-roam-mode-imenu-create-index)))
+          (expect (caar index) :to-equal "Unlinked References")))))
+
+  (it "creates flat entry for node without preview"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((mock-node (org-roam-node-create :title "Simple Node"))
+             (node-section (test--make-node-section 50 mock-node nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10 (list node-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (backlinks-entry (car index))
+               (node-entry (cadr (cdr backlinks-entry))))
+          (expect (car node-entry) :to-equal "Simple Node")
+          (expect (numberp (cdr node-entry)) :to-be t)))))
+
+  (it "handles nil row and col in grep entries"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((grep-section (test--make-grep-section 100 "/tmp/test.org" nil nil))
+             (unlinked-section (test--make-magit-section 'unlinked-references 10 (list grep-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list unlinked-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (unlinked-entry (car index))
+               (grep-entries (cdr (cdr unlinked-entry))))
+          (expect (caar grep-entries) :to-equal "test.org:0:0")))))
+
+  (it "preserves order of multiple node entries"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((node1 (org-roam-node-create :title "First Node"))
+             (node2 (org-roam-node-create :title "Second Node"))
+             (node3 (org-roam-node-create :title "Third Node"))
+             (node-section1 (test--make-node-section 50 node1 nil))
+             (node-section2 (test--make-node-section 100 node2 nil))
+             (node-section3 (test--make-node-section 150 node3 nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10
+                                                          (list node-section1
+                                                                node-section2
+                                                                node-section3)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (backlinks-entry (car index))
+               (node-entries (cddr backlinks-entry)))
+          (expect (length node-entries) :to-equal 3)
+          (expect (car (nth 0 node-entries)) :to-equal "First Node")
+          (expect (car (nth 1 node-entries)) :to-equal "Second Node")
+          (expect (car (nth 2 node-entries)) :to-equal "Third Node")))))
+
+  (it "skips nodes with nil title"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((valid-node (org-roam-node-create :title "Valid Node"))
+             (nil-title-node (org-roam-node-create :title nil))
+             (valid-section (test--make-node-section 50 valid-node nil))
+             (nil-section (test--make-node-section 100 nil-title-node nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10
+                                                          (list valid-section nil-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (backlinks-entry (car index))
+               (node-entries (cddr backlinks-entry)))
+          (expect (length node-entries) :to-equal 1)
+          (expect (car (car node-entries)) :to-equal "Valid Node")))))
+
+  (it "skips nodes with empty string title"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((valid-node (org-roam-node-create :title "Valid Node"))
+             (empty-title-node (org-roam-node-create :title ""))
+             (valid-section (test--make-node-section 50 valid-node nil))
+             (empty-section (test--make-node-section 100 empty-title-node nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10
+                                                          (list valid-section empty-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (backlinks-entry (car index))
+               (node-entries (cddr backlinks-entry)))
+          (expect (length node-entries) :to-equal 1)
+          (expect (car (car node-entries)) :to-equal "Valid Node")))))
+
+  (it "skips node sections with nil node object"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((valid-node (org-roam-node-create :title "Valid Node"))
+             (valid-section (test--make-node-section 50 valid-node nil))
+             (nil-node-section (test--make-node-section 100 nil nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10
+                                                          (list valid-section nil-node-section)))
+             (root-section (test--make-magit-section 'org-roam 1 (list backlinks-section))))
+        (setq magit-root-section root-section)
+        (let* ((index (org-roam-mode-imenu-create-index))
+               (backlinks-entry (car index))
+               (node-entries (cddr backlinks-entry)))
+          (expect (length node-entries) :to-equal 1)
+          (expect (car (car node-entries)) :to-equal "Valid Node")))))
+
+  (it "creates index for mixed section types"
+    (with-temp-buffer
+      (org-roam-mode)
+      (let* ((backlink-node (org-roam-node-create :title "Backlink Node"))
+             (backlink-node-section (test--make-node-section 50 backlink-node nil))
+             (backlinks-section (test--make-magit-section 'org-roam-backlinks 10
+                                                          (list backlink-node-section)))
+             (reflink-node (org-roam-node-create :title "Reflink Node"))
+             (reflink-node-section (test--make-node-section 200 reflink-node nil))
+             (reflinks-section (test--make-magit-section 'org-roam-reflinks 150
+                                                         (list reflink-node-section)))
+             (grep-section (test--make-grep-section 350 "/tmp/unlinked.org" 10 5))
+             (unlinked-section (test--make-magit-section 'unlinked-references 300
+                                                         (list grep-section)))
+             (root-section (test--make-magit-section 'org-roam 1
+                                                     (list backlinks-section
+                                                           reflinks-section
+                                                           unlinked-section))))
+        (setq magit-root-section root-section)
+        (let ((index (org-roam-mode-imenu-create-index)))
+          (expect index :not :to-be nil)
+          (expect (length index) :to-equal 3)
+          (expect (car (nth 0 index)) :to-equal "Backlinks")
+          (expect (car (nth 1 index)) :to-equal "Reflinks")
+          (expect (car (nth 2 index)) :to-equal "Unlinked References"))))))
 
 (provide 'test-org-roam-mode)
 


### PR DESCRIPTION
## Summary

Add imenu navigation to `org-roam-mode` buffers, enabling users to quickly jump between sections (Backlinks, Reflinks, Unlinked References) and individual node entries using `M-x imenu` or `consult-imenu`.

Fixes #2274

<img width="2322" height="1242" alt="CleanShot 2026-01-31 at 20 46 30@2x" src="https://github.com/user-attachments/assets/a2c495c8-6fd9-4e44-a621-ad95f4c07c8c" />


## Implementation

- Add `org-roam-mode-imenu-create-index` function as the `imenu-create-index-function`
- Registry pattern via `org-roam-mode-imenu--section-types` for extensibility
- Nested alist format with `*Section*` and `*Node*` markers for hierarchical navigation
- Full compatibility with `consult-imenu` and `imenu-list`

## Test Plan

- [x] 14 test cases covering all section types
- [x] Edge cases: nil values, empty sections, order preservation
- [x] Mixed section types in single buffer
- [x] Manual testing with `M-x imenu` and `consult-imenu`
