### PR TITLE
feat: Add default exclude for lockfiles

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -142,7 +142,9 @@ responsibility to ensure that."
   :type '(repeat string)
   :group 'org-roam)
 
-(defcustom org-roam-file-exclude-regexp (list org-attach-id-dir)
+(defcustom org-roam-file-exclude-regexp
+  (list (rx (or bos "/") ".#") ; Info node `(elisp)File Locks'
+        org-attach-id-dir)
   "Files matching this regexp or list of regexps are excluded from Org-roam."
   :type '(choice
           (repeat


### PR DESCRIPTION
###### Motivation for this change

Make sure not to accidentally add a "file lock" file to the DB.

While a good idea in general, it also lets us worry less about writing tests, as it should prevent issues like #2579 from recurring.

Relevant documentation:

> The file lock is really a file, a symbolic link with a special name, stored in the same directory as the file you are editing.  The name is constructed by prepending `.#` to the file name of the buffer. 

https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html

> If your file system does not support symbolic links, a regular file is used.

https://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html#FOOT7

In case you wonder about the form

```elisp
(rx (or bos "/") ".#")
```

it's because `org-roam-file-exclude-regexp` applies to *relative* file names. Relative to org-roam-directory. 

Let's say org-roam-directory is `~/org/`, then a lockfile `~/org/.#file.org` has the relative name `".#file.org"`, with no initial slash.