### PR TITLE
Faster `org-roam-list-files` for the third time (now based on `truename-cache`)

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -669,8 +669,8 @@ of passing it directly through the shell command line."
                        titles "")))
 
   (concat "rg --follow --only-matching --vimgrep --pcre2 --ignore-case "
-          (mapconcat (lambda (glob) (concat "--glob " glob))
-                     (org-roam--list-files-search-globs org-roam-file-extensions)
+          (mapconcat (lambda (suffix) (concat "--glob \"*" suffix "\""))
+                     (org-roam-suffixes)
                      " ")
           " --file " (shell-quote-argument temp-file) " "
           (shell-quote-argument (expand-file-name org-roam-directory))))

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -102,8 +102,8 @@ FN must take two arguments: the key and the value."
   "Calculate a set of file name suffixes out of `org-roam-file-extensions'."
   (cl-loop for ext in org-roam-file-extensions
            collect (concat "." ext)
-           collect (concat "." ext ".age")
-           collect (concat "." ext ".gpg")))
+           collect (concat "." ext ".gpg")
+           collect (concat "." ext ".age")))
 
 (defun org-roam-directory-files-and-attributes (&optional dir)
   "Return an alist \((FILE1 . ATTR1) (FILE2 . ATTR2) ...\).

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.3.1
-;; Package-Requires: ((emacs "26.1") (compat "30.1") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (compat "30.1") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0") (truename-cache "0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -132,6 +132,29 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
 Each function takes two arguments: the id of the node, and the link description."
   :group 'org-roam
   :type 'hook)
+
+(defcustom org-roam-dir-exclude-regexps
+  (let ((literals
+         (append (unless (file-name-absolute-p org-attach-id-dir)
+                   (list org-attach-id-dir))
+                 '("logseq/version-files/"  ; Duplicates of every Org file
+                   "logseq/bak/"  ; Duplicates of every Org file
+                   ".git/"  ; Many sub-sub-subdirs
+                   ".hg/"))))
+    (list (rx ".pam/")  ; pamparam (many files inside)
+          (rx (or bos "/") (regexp (regexp-opt literals)))))
+  "If a directory name matches any of these regexps, skip it.
+
+Like `org-roam-file-exclude-regexp', this applies to the part of its
+file-name after `org-roam-directory' \(i.e. the relative name\), but
+with a trailing slash.
+
+You can also use `org-roam-file-exclude-regexp' for the same purpose of
+preventing recursion into directories - the separation is just helpful
+for the performance of `org-roam-db-sync', so the dir regexps are not
+also checked against each each file name."
+  :group 'org-roam
+  :type '(repeat regexp))
 
 (defcustom org-roam-file-extensions '("org")
   "List of file extensions to be included by Org-Roam.

--- a/org-roam.el
+++ b/org-roam.el
@@ -93,8 +93,6 @@
 (require 'org-element)
 (require 'org-capture)
 
-(require 'ansi-color) ; to strip ANSI color codes in `org-roam--list-files'
-
 (eval-when-compile
   (require 'subr-x))
 
@@ -173,51 +171,6 @@ responsibility to ensure that."
           (const :tag "Include everything" nil))
   :group 'org-roam)
 
-;; TODO: Deprecate, the elisp method is likely faster now.
-(defcustom org-roam-list-files-commands nil
-  "Commands that will be used to find Org-roam files.
-
-It should be a list of symbols or cons cells representing any of
-the following supported file search methods.
-
-The commands will be tried in order until an executable for a
-command is found. The Elisp implementation is used if no command
-in the list is found.
-
-  `find'
-
-    Use find as the file search method.
-    Example command:
-      find /path/to/dir -type f \
-        \( -name \"*.org\" -o -name \"*.org.gpg\" -name \"*.org.age\" \)
-
-  `fd'
-
-    Use fd as the file search method.
-    Example command:
-      fd /path/to/dir/ --type file -e \".org\" -e \".org.gpg\" -e \".org.age\"
-
-  `fdfind'
-
-    Same as `fd'. It's an alias that used in some OSes (e.g. Debian, Ubuntu)
-
-  `rg'
-
-    Use ripgrep as the file search method.
-    Example command:
-       rg /path/to/dir/ --files -g \"*.org\" -g \"*.org.gpg\" -g \"*.org.age\"
-
-By default, `executable-find' will be used to look up the path to
-the executable. If a custom path is required, it can be specified
-together with the method symbol as a cons cell. For example:
-\\='(find (rg . \"/path/to/rg\"))."
-  :type '(set
-          (const :tag "find" find)
-          (const :tag "fd" fd)
-          (const :tag "fdfind" fdfind)
-          (const :tag "rg" rg)
-          (const :tag "elisp" nil)))
-
 ;;; Library
 (defun org-roam-file-p (&optional file)
   "Return t if FILE is an Org-roam file, nil otherwise.
@@ -259,7 +212,7 @@ FILE is an Org-roam file if:
   "Return a list of all Org-roam files under `org-roam-directory'.
 See `org-roam-file-p' for how each file is determined to be as
 part of Org-Roam."
-  (org-roam--list-files (expand-file-name org-roam-directory)))
+  (mapcar #'car (org-roam-directory-files-and-attributes)))
 
 (defun org-roam-buffer-p (&optional buffer)
   "Return t if BUFFER is for an Org-roam file.
@@ -279,80 +232,6 @@ Like `file-name-extension', but does not strip version number."
       (if (and (string-match "\\.[^.]*\\'" file)
                (not (eq 0 (match-beginning 0))))
           (substring file (+ (match-beginning 0) 1))))))
-
-(defun org-roam--list-files (dir)
-  "Return all Org-roam files located recursively within DIR.
-Use external shell commands if defined in `org-roam-list-files-commands'."
-  (let (path exe)
-    (cl-dolist (cmd org-roam-list-files-commands)
-      (pcase cmd
-        (`(,e . ,path)
-         (setq path (executable-find path)
-               exe  (symbol-name e)))
-        ((pred symbolp)
-         (setq path (executable-find (symbol-name cmd))
-               exe (symbol-name cmd)))
-        (wrong-type
-         (signal 'wrong-type-argument
-                 `((consp symbolp)
-                   ,wrong-type))))
-      (when path (cl-return)))
-    (if-let* ((files (when path
-                       (let ((fn (intern (concat "org-roam--list-files-" exe))))
-                         (unless (fboundp fn) (user-error "%s is not an implemented search method" fn))
-                         (funcall fn path (format "\"%s\"" dir)))))
-              (files (seq-filter #'org-roam-file-p files))
-              (files (mapcar #'expand-file-name files))) ; canonicalize names
-        files
-      (org-roam--list-files-elisp dir))))
-
-(defun org-roam--shell-command-files (cmd)
-  "Run CMD in the shell and return a list of files.
-If no files are found, an empty list is returned."
-  (thread-last cmd
-               shell-command-to-string
-               ansi-color-filter-apply
-               (funcall (lambda (str) (split-string str "\n")))
-               (seq-filter (lambda (s)
-                             (not (or (null s) (string= "" s)))))))
-
-(defun org-roam--list-files-search-globs (exts)
-  "Given EXTS, return a list of search globs.
-E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
-  (cl-loop for e in exts
-           append (list (format "\"*.%s\"" e)
-                        (format "\"*.%s.gpg\"" e)
-                        (format "\"*.%s.age\"" e))))
-
-(defun org-roam--list-files-find (executable dir)
-  "Return all Org-roam files under DIR, using \"find\", provided as EXECUTABLE."
-  (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (names (string-join (mapcar (lambda (glob) (concat "-name " glob)) globs) " -o "))
-         (command (string-join `(,executable "-L" ,dir "-type f \\(" ,names "\\)") " ")))
-    (org-roam--shell-command-files command)))
-
-(defun org-roam--list-files-fd (executable dir)
-  "Return all Org-roam files under DIR, using \"fd\", provided as EXECUTABLE."
-  (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (extensions (string-join (mapcar (lambda (glob) (concat "-e " (substring glob 2 -1))) globs) " "))
-         (command (string-join `(,executable "-L" "--type file" ,extensions "." ,dir) " ")))
-    (org-roam--shell-command-files command)))
-
-(defalias 'org-roam--list-files-fdfind #'org-roam--list-files-fd)
-
-(defun org-roam--list-files-rg (executable dir)
-  "Return all Org-roam files under DIR, using \"rg\", provided as EXECUTABLE."
-  (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (command (string-join `(
-                                 ,executable "-L" ,dir "--files"
-                                 ,@(mapcar (lambda (glob) (concat "-g " glob)) globs)) " ")))
-    (org-roam--shell-command-files command)))
-
-(declare-function org-roam--directory-files-recursively "org-roam-compat")
-
-(defun org-roam--list-files-elisp (dir)
-  "Return all Org-roam files under DIR, using Elisp based implementation."
-  (mapcar #'car (org-roam-directory-files-and-attributes dir)))
 
 ;;; Package bootstrap
 (provide 'org-roam)

--- a/org-roam.el
+++ b/org-roam.el
@@ -354,14 +354,7 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 
 (defun org-roam--list-files-elisp (dir)
   "Return all Org-roam files under DIR, using Elisp based implementation."
-  (let ((regex (concat "\\.\\(?:"(mapconcat
-                                  #'regexp-quote org-roam-file-extensions
-                                  "\\|" )"\\)\\(?:\\.gpg\\|\\.age\\)?\\'"))
-        result)
-    (dolist (file (org-roam--directory-files-recursively dir regex nil nil t) result)
-      (when (and (file-readable-p file)
-                 (org-roam-file-p file))
-        (push file result)))))
+  (mapcar #'car (org-roam-directory-files-and-attributes dir)))
 
 ;;; Package bootstrap
 (provide 'org-roam)

--- a/org-roam.el
+++ b/org-roam.el
@@ -173,10 +173,8 @@ responsibility to ensure that."
           (const :tag "Include everything" nil))
   :group 'org-roam)
 
-(defcustom org-roam-list-files-commands
-  (if (member system-type '(windows-nt ms-dos cygwin))
-      nil
-    '(find fd fdfind rg))
+;; TODO: Deprecate, the elisp method is likely faster now.
+(defcustom org-roam-list-files-commands nil
   "Commands that will be used to find Org-roam files.
 
 It should be a list of symbols or cons cells representing any of

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -57,6 +57,13 @@
     (org-roam-db--close)
     (delete-file org-roam-db-location))
 
+  (it "returns absolute paths"
+    (expect (cl-every #'file-name-absolute-p (org-roam-list-files))))
+
+  (it "returns unique paths"
+    (expect (= (length (org-roam-list-files))
+               (length (delete-dups (org-roam-list-files))))))
+
   (it "gets files correctly"
     (expect (mapcar #'file-name-nondirectory (org-roam-list-files))
             :to-have-same-items-as
@@ -79,6 +86,11 @@
   (it "does not care if org-roam-directory itself matches an exclude rule"
     (setq org-roam-file-exclude-regexp (regexp-quote org-roam-directory))
     (expect (length (org-roam-list-files)) :to-equal 13))
+
+  ;; https://github.com/org-roam/org-roam/pull/2178
+  (it "applies org-roam-file-exclude-regexp to the part of file name after org-roam-directory"
+    (setq org-roam-file-exclude-regexp "dailies.*2025")
+    (expect (length (org-roam-list-files)) :to-equal 12))
 
   (it "respects org-roam-file-extensions"
     (setq org-roam-file-extensions '("md"))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -102,13 +102,6 @@
     (setq org-roam-file-exclude-regexp (regexp-quote "foo.org"))
     (expect (length (org-roam-list-files)) :to-equal 12)))
 
-(describe "org-roam--list-files-search-globs"
-
-  (it "returns the correct list of globs"
-    (expect (org-roam--list-files-search-globs org-roam-file-extensions)
-            :to-have-same-items-as
-            '("\"*.org\"" "\"*.org.gpg\"" "\"*.org.age\""))))
-
 (provide 'test-org-roam)
 
 ;;; test-org-roam.el ends here


### PR DESCRIPTION
This is a rehash of https://github.com/org-roam/org-roam/pull/2558, but outsources the grunt code to a separate library I wrote: [truename-cache](https://github.com/meedstrom/truename-cache
)  

I have another use-case for the same library, which will also switch soon (https://github.com/meedstrom/org-mem/pull/38).

I don't know if org-roam particularly wants to rely on it, that's up to you guys.

TODO:
- [ ] Add test that verifies `org-roam-file-p` on every file returned by `org-roam-list-files`.
- [ ] Add symlinks among the `tests/roam-files/` files.  At least one symlink should point to somewhere outside that directory.  One should be inaccessible. One should have a name ending in ".org" but actually point to a directory.