### PR TITLE
Handle nil schema version in org-roam-db

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -128,7 +128,11 @@ Performs a database upgrade when required."
         (when init-db
           (org-roam-db--init conn))
         (let* ((version (caar (emacsql conn "PRAGMA user_version")))
-               (version (org-roam-db--upgrade-maybe conn version)))
+               (version (if (integerp version)
+                            (org-roam-db--upgrade-maybe conn version)
+                          (emacsql-close conn)
+                          (error "Org-roam: could not read schema version from %s"
+                                 org-roam-db-location))))
           (cond
            ((> version org-roam-db-version)
             (emacsql-close conn)


### PR DESCRIPTION
## Summary

When using `emacsql-sqlite-builtin` (Emacs 29+), the `PRAGMA user_version` query can transiently return nil instead of an integer. This causes `org-roam-db--upgrade-maybe` to signal `(wrong-type-argument number-or-marker-p nil)` when it compares the version with `<`.

The fix guards the version with `integerp` before passing it to `org-roam-db--upgrade-maybe`. When the version is not an integer, the connection is closed (so the next call retries cleanly via the existing `emacsql-live-p` check) and a descriptive error is signaled.

## Backtrace

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  org-roam-db--upgrade-maybe(#<emacsql-sqlite-builtin-connection ...> nil)
  org-roam-db()
  org-roam-db-sync()
  apply(org-roam-db-sync nil)
  timer-event-handler([t 0 1200 0 t org-roam-db-sync nil idle 0 nil])
```

## Environment

- Emacs 30.2 with built-in SQLite (`emacsql-sqlite-builtin`)
- org-roam v2 (commit 18dfe81)