### PR TITLE
minor: Make docstring consistent with function behavior

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -476,7 +476,7 @@ NODE, unless FORCE is non-nil."
   (org-fold-show-context))
 
 (defun org-roam-node-visit (node &optional other-window force)
-  "From the current buffer, visit NODE. Return the visited buffer.
+  "From the current buffer, visit NODE.
 Display the buffer in the selected window.  With a prefix
 argument OTHER-WINDOW display the buffer in another window
 instead.


### PR DESCRIPTION
###### Motivation for this change

`org-roam-node-visit` delegates to `org-roam-node-open`, which does not return the visited buffer. The docstring provides an inconsistent description of the function behavior.

Alternatively, we might actually make `org-roam-node-visit` return the visited buffer. I'm not sure which is desired, but it may be better to keep the existing behavior.