### PR TITLE
test(mode): add regression for tilde org-roam-directory in rg command

### DIFF
--- a/tests/test-org-roam-mode.el
+++ b/tests/test-org-roam-mode.el
@@ -32,7 +32,13 @@
   (it "returns the correct rg command for unlinked references"
     (expect (org-roam-unlinked-references--rg-command '("foo" "bar") "/tmp/regex")
             :to-equal
-            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" --file /tmp/regex /tmp/org\\ roam")))
+            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" --file /tmp/regex /tmp/org\\ roam"))
+
+  (it "expands tilde paths before shell quoting"
+    (setq org-roam-directory "~/org/roam")
+    (let ((command (org-roam-unlinked-references--rg-command '("Site Controller") "/tmp/regex")))
+      (expect command :to-match (regexp-quote (expand-file-name org-roam-directory)))
+      (expect command :not :to-match "\\\\~/"))))
 
 (provide 'test-org-roam-mode)
 


### PR DESCRIPTION
Closes #2478.

## Summary
Adds a regression test for `org-roam-unlinked-references--rg-command` to verify that `org-roam-directory` paths using `~` are expanded before shell quoting.

## Why
Issue #2478 reports `rg` failing with paths like `\\~/org/roam`.
A prior fix addressed path expansion, but this behavior was not covered by tests.

## Checks done
- `eldev -C --unstable -T test --file tests/test-org-roam-mode.el .`
- Result: `Ran 2 specs, 0 failed`
